### PR TITLE
docs: add README icon banner, drop Project Structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/icon/icon.png" alt="Open Weather Wizard icon" width="128" height="128">
+</p>
+
 # Open Weather Wizard
 
 [![CI](https://github.com/arunkumar-mourougappane/open-weather-wizard/actions/workflows/ci.yml/badge.svg)](https://github.com/arunkumar-mourougappane/open-weather-wizard/actions/workflows/ci.yml)
@@ -111,32 +115,6 @@ Delete the file to reset to defaults.
 **Reset configuration:**
 
 - Delete the config file at the path listed above and restart the app.
-
-## Project Structure
-
-```text
-.
-├── assets/
-│   ├── lottie/           # Hand-authored Lottie animations (one per weather condition)
-│   ├── static/           # Static SVG fallback icons
-│   ├── animated/         # Reference-only CSS-animated SVGs the Lottie set was authored from
-│   └── icon/             # App icon
-├── docs/                 # Architecture, UI design, and icon-mapping notes
-├── examples/              # Demo/integration-test binaries
-├── src/
-│   ├── app.rs             # iced root: AppState, Message, update(), view(), subscription()
-│   ├── config.rs          # Config load/save
-│   ├── lib.rs              # Library crate root
-│   ├── main.rs             # Binary entry point
-│   ├── ui/                 # Per-screen views (main screen, forecast row, preferences, about,
-│   │                       # skeleton loading state, cross-fade transitions, shared styling)
-│   │   └── lottie/         # velato/vello <-> iced wgpu integration
-│   └── weather_api/        # Provider trait + OpenWeatherMap and Google Weather implementations
-├── Cargo.toml
-├── install.sh              # Linux install script (binary + desktop integration)
-├── open-weather-wizard.desktop
-└── LICENSE
-```
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add the new app icon as a centered banner at the top of `README.md`.
- Remove the "Project Structure" directory-tree section — it had already gone stale (still referenced the removed `assets/animated/` dir) and duplicates what's easy to see from the repo itself. Per the repo owner's request, don't re-add this section.

## Test plan

- [x] Rendered README locally to confirm the icon image path resolves and formatting is intact