### PR TITLE
docs: move README icon inline with the title

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "open-weather-wizard"
 version = "0.2.0"
 edition = "2024"
-authors = ["Arunkumar Mourougappane <amouroug@buffalo.edu>"]
+authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]
 description = "A simple, elegant desktop weather app with animated Lottie icons, a 5-day forecast, and a silent cross-faded auto-refresh, built in Rust with iced."
 homepage = "https://github.com/arunkumar-mourougappane/open-weather-wizard"
 repository = "https://github.com/arunkumar-mourougappane/open-weather-wizard"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<p align="center">
-  <img src="assets/icon/icon.png" alt="Open Weather Wizard icon" width="128" height="128">
-</p>
-
-# Open Weather Wizard
+# <img src="assets/icon/icon.png" alt="" width="40" height="40"> Open Weather Wizard
 
 [![CI](https://github.com/arunkumar-mourougappane/open-weather-wizard/actions/workflows/ci.yml/badge.svg)](https://github.com/arunkumar-mourougappane/open-weather-wizard/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/open-weather-wizard.svg)](https://crates.io/crates/open-weather-wizard)


### PR DESCRIPTION
## Summary

- Replace the standalone centered icon block above the `# Open Weather Wizard` heading with an inline `<img>` inside the heading line, so the icon sits next to the title instead of floating above it.

Small follow-up to feedback on how the icon looked on the GitHub README page.

## Test plan

- [ ] Visually confirm on GitHub after merge that the icon renders inline at 40x40 next to the title