### PR TITLE
Integrate real Google Weather API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,10 +2319,12 @@ checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link",
 ]
 
 [[package]]
@@ -2334,6 +2336,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -3387,6 +3404,7 @@ dependencies = [
  "env_logger",
  "iced",
  "image",
+ "jiff",
  "keyring",
  "log",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ wgpu = "27.0.1"
 image = { version = "0.25.10", default-features = false, features = ["png"] }
 open = "5.3.2"
 keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
+jiff = "0.2.31"
 
 [[bin]]
 name = "open-weather-wizard"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ become the body of the GitHub Release created by
 
 ## Unreleased
 
+**Providers**
+
+- Google Weather is now a real, live provider (Google Maps Platform's
+  Weather API) instead of a hardcoded mock — current conditions and a real
+  5-day forecast, both requiring your own Google Cloud API key (entered the
+  same way as the OpenWeatherMap token, in Preferences). Because Google's
+  free tier is capped at 10,000 calls/month, this provider auto-refreshes
+  every 15 minutes instead of OpenWeatherMap's 30 seconds. See
+  `docs/GOOGLE_WEATHER_API.md` for the full integration details.
+
 ## v0.2.0
 
 The GTK4 UI from v0.1.0 is gone — the app is rebuilt from scratch on

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,14 +86,16 @@ problem that doesn't exist here.
 
 ### Fetch lifecycle
 
-`RefreshRequested` (manual, via Preferences Save) and `Tick` (the 30s
-auto-refresh subscription) both set `weather`/`forecast` to `Loading` and
-return `Task::batch([fetch_weather_task, fetch_forecast_task])`
-(`Task::perform` wrapping the existing `WeatherProviderFactory` +
-`WeatherProvider::get_weather`/`get_forecast` calls). The two fetches resolve
-**independently** — `WeatherFetched`/`ForecastFetched` each update their own
-status — so a forecast failure, or Google Weather's intentional empty
-placeholder, never blanks out current conditions.
+`RefreshRequested` (manual, via Preferences Save) and `Tick` (the
+auto-refresh subscription — 30s for OpenWeatherMap, 15 minutes for Google
+Weather to stay within its free-tier call quota, see `GOOGLE_WEATHER_
+REFRESH_INTERVAL` in `src/app.rs` and `docs/GOOGLE_WEATHER_API.md`) both set
+`weather`/`forecast` to `Loading` and return `Task::batch([fetch_weather_task,
+fetch_forecast_task])` (`Task::perform` wrapping the existing
+`WeatherProviderFactory` + `WeatherProvider::get_weather`/`get_forecast`
+calls). The two fetches resolve **independently** — `WeatherFetched`/
+`ForecastFetched` each update their own status — so a forecast failure never
+blanks out current conditions.
 
 ### Subscriptions
 
@@ -172,19 +174,25 @@ symbol.
 ## Testing
 
 All pre-existing tests in `src/lib.rs` (`config` roundtrip/serialization,
-`WeatherProviderFactory`, `Arc<Mutex<AppConfig>>` thread-safety,
-`GoogleWeatherProvider::get_weather`) were kept unchanged — none depended on
-GTK. Added:
+`WeatherProviderFactory`, `Arc<Mutex<AppConfig>>` thread-safety) were kept
+unchanged — none depended on GTK. Added:
 
 - `test_forecast_aggregation` — the one genuinely new nontrivial business
   logic (`aggregate_daily`'s daily bucketing/midday-condition selection),
   exercised against a hand-built fixture spanning two days of mixed
   conditions.
-- `test_google_weather_forecast_is_empty` — confirms the empty-placeholder
-  contract for the mock provider.
 - `test_lottie_assets_parse` — confirms the four hand-authored Lottie JSON
   files under `assets/lottie/` are valid, non-empty compositions; catches
   malformed JSON before it reaches the animated-icon widget.
+
+`GoogleWeatherProvider` (`src/weather_api/google_weather_api.rs`) is a real
+network-backed provider now, not a mock — its `#[cfg(test)]` module tests
+the pure/deterministic pieces only (condition-type mapping, unit
+conversions, response deserialization against hand-built JSON fixtures, and
+RFC 3339/timezone resolution), the same fixture-based philosophy as
+`test_forecast_aggregation`, since `cargo test` has neither network access
+nor a real API key. `examples/google_weather_test.rs` is the live smoke test
+for the actual HTTP integration, run manually (see `docs/GOOGLE_WEATHER_API.md`).
 
 `view()` functions are not unit-tested (no established snapshot-testing
 tooling in this codebase's dependency budget, and asserting on `Element`

--- a/examples/google_weather_test.rs
+++ b/examples/google_weather_test.rs
@@ -1,0 +1,86 @@
+//!
+//! This example demonstrates how to use the Google Weather API provider to
+//! fetch real-time weather data. It initializes a configuration for Peoria,
+//! IL, creates a `GoogleWeather` provider using an API key read from the
+//! `GOOGLE_WEATHER_API_KEY` environment variable, and then attempts to fetch
+//! and display the current weather conditions and forecast.
+//!
+//! This serves as a live integration test to verify that the Google Weather
+//! API implementation is working correctly. Run it with:
+//!
+//! ```sh
+//! GOOGLE_WEATHER_API_KEY=your-key-here cargo run --example google_weather_test
+//! ```
+use open_weather_wizard::config::{LocationConfig, WeatherApiProvider};
+use open_weather_wizard::weather_api::weather_provider::WeatherProviderFactory;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Google Weather API Integration Test");
+    println!("====================================\n");
+
+    let location = LocationConfig {
+        city: "Peoria".to_string(),
+        state: "IL".to_string(),
+        country: "US".to_string(),
+    };
+
+    // Never hardcode a real API key in source -- read it from the
+    // environment instead. This example is a live integration test, run
+    // manually by a developer who has their own key, not something CI
+    // executes automatically.
+    let api_key = std::env::var("GOOGLE_WEATHER_API_KEY").map_err(|_| {
+        "Set the GOOGLE_WEATHER_API_KEY environment variable to your own Google Cloud API key \
+         (with the Weather API enabled) before running this example \
+         (e.g. `GOOGLE_WEATHER_API_KEY=... cargo run --example google_weather_test`)"
+    })?;
+
+    println!("Testing Google Weather API Provider...");
+    println!("Location: Peoria, IL, US");
+    println!(
+        "Using provided API key: {}...",
+        &api_key[..8.min(api_key.len())]
+    );
+
+    let provider =
+        WeatherProviderFactory::create_provider(&WeatherApiProvider::GoogleWeather, Some(api_key))?;
+
+    match provider.get_weather(&location).await {
+        Ok(weather_data) => {
+            println!("\n✅ Google Weather API Provider works!");
+            println!("   City: {}", weather_data.name);
+            println!("   Temperature: {:.1}°C", weather_data.main.temp);
+            println!("   Description: {}", weather_data.weather[0].description);
+            println!("   Humidity: {}%", weather_data.main.humidity);
+            println!("   Weather condition: {}", weather_data.weather[0].main);
+            println!(
+                "   Sunrise/sunset (unix): {} / {}",
+                weather_data.sys.sunrise, weather_data.sys.sunset
+            );
+            println!("   Timezone offset (s): {}", weather_data.timezone);
+        }
+        Err(e) => {
+            println!("\n⚠️  Google Weather API call failed: {:?}", e);
+            println!("   This might be due to network issues or API key limitations.");
+        }
+    }
+
+    match provider.get_forecast(&location).await {
+        Ok(forecast) => {
+            println!("\n✅ Google Weather forecast fetched!");
+            for day in &forecast.days {
+                println!(
+                    "   {}: {:.0}°C / {:.0}°C -- {}",
+                    day.date, day.temp_max, day.temp_min, day.description
+                );
+            }
+        }
+        Err(e) => {
+            println!("\n⚠️  Google Weather forecast call failed: {:?}", e);
+        }
+    }
+
+    println!("\n✅ Google Weather API integration test completed!");
+
+    Ok(())
+}

--- a/examples/openweather_test.rs
+++ b/examples/openweather_test.rs
@@ -29,7 +29,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.location = LocationConfig {
         city: "London".to_string(),
         state: "".to_string(),
-        country: "UK".to_string(),
+        // OpenWeatherMap's geocoding endpoint expects an ISO 3166-1 alpha-2
+        // country code -- "UK" isn't one (the correct code is "GB") and
+        // silently returns zero results rather than an error.
+        country: "GB".to_string(),
     };
 
     // Never hardcode a real API key in source -- read it from the
@@ -66,6 +69,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("\n⚠️  OpenWeather API call failed: {:?}", e);
             println!("   This might be due to network issues or API key limitations.");
             println!("   The provider factory and configuration system work correctly.");
+        }
+    }
+
+    match provider.get_forecast(&config.location).await {
+        Ok(forecast) => {
+            println!("\n✅ OpenWeather forecast fetched!");
+            for day in &forecast.days {
+                println!(
+                    "   {}: {:.0}°C / {:.0}°C -- {}",
+                    day.date, day.temp_max, day.temp_min, day.description
+                );
+            }
+        }
+        Err(e) => {
+            println!("\n⚠️  OpenWeather forecast call failed: {:?}", e);
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use iced::widget::Space;
 use iced::{Element, Size, Subscription, Task, Theme, window};
 
-use crate::config::{AppConfig, ConfigManager};
+use crate::config::{AppConfig, ConfigManager, WeatherApiProvider};
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
     speed_to_display, speed_unit, unit_symbol,
@@ -37,6 +37,13 @@ const MAIN_WINDOW_MIN_SIZE: Size = Size::new(480.0, 420.0);
 /// width needs at least this much room before fields start getting crushed.
 const PREFERENCES_WINDOW_MIN_SIZE: Size = Size::new(440.0, 400.0);
 const AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+/// A full refresh against the real Google Weather API costs 3 billable
+/// calls (`currentConditions:lookup` + two `forecast/days:lookup` calls --
+/// see `docs/GOOGLE_WEATHER_API.md`). At 15 minutes that's ~8,640 calls/month
+/// for one always-open instance, comfortably under Google's 10,000/month
+/// free tier; `AUTO_REFRESH_INTERVAL`'s 30s would blow through it in about a
+/// day.
+const GOOGLE_WEATHER_REFRESH_INTERVAL: Duration = Duration::from_secs(15 * 60);
 /// Drives redraws for the animated Lottie icons (~30fps); `icons::view`
 /// computes each frame from wall-clock time, so this tick carries no state of
 /// its own -- it exists purely to make iced re-invoke `view()` regularly.
@@ -469,9 +476,13 @@ pub fn view(state: &AppState, window_id: window::Id) -> Element<'_, Message> {
     Space::new().into()
 }
 
-pub fn subscription(_state: &AppState) -> Subscription<Message> {
+pub fn subscription(state: &AppState) -> Subscription<Message> {
+    let refresh_interval = match state.config.weather_provider {
+        WeatherApiProvider::GoogleWeather => GOOGLE_WEATHER_REFRESH_INTERVAL,
+        WeatherApiProvider::OpenWeather => AUTO_REFRESH_INTERVAL,
+    };
     Subscription::batch([
-        iced::time::every(AUTO_REFRESH_INTERVAL).map(Message::Tick),
+        iced::time::every(refresh_interval).map(Message::Tick),
         iced::time::every(ANIMATION_TICK_INTERVAL).map(|_| Message::AnimationTick),
         window::close_requests().map(Message::WindowCloseRequested),
     ])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,15 @@ mod tests {
             WeatherProviderFactory::create_provider(&WeatherApiProvider::OpenWeather, None);
         assert!(result.is_err());
 
-        // Test Google Weather provider (doesn't need API key)
+        // Google Weather now requires a real API token, same as OpenWeather.
         let result =
             WeatherProviderFactory::create_provider(&WeatherApiProvider::GoogleWeather, None);
+        assert!(result.is_err());
+
+        let result = WeatherProviderFactory::create_provider(
+            &WeatherApiProvider::GoogleWeather,
+            Some("test_key".to_string()),
+        );
         assert!(result.is_ok());
     }
 
@@ -178,27 +184,6 @@ mod tests {
             assert_eq!(config_guard.location.city, "Updated City");
             assert_eq!(config_guard.get_api_token().unwrap(), "new_token");
         }
-    }
-
-    /// An asynchronous test to verify that the mock `GoogleWeatherProvider` works as expected.
-    #[tokio::test]
-    async fn test_google_weather_provider() {
-        use crate::weather_api::google_weather_api::GoogleWeatherProvider;
-        use crate::weather_api::weather_provider::WeatherProvider;
-
-        let provider = GoogleWeatherProvider::new();
-        let location = LocationConfig {
-            city: "Test City".to_string(),
-            state: "TS".to_string(),
-            country: "TC".to_string(),
-        };
-
-        let result = provider.get_weather(&location).await;
-        assert!(result.is_ok());
-
-        let weather_data = result.unwrap();
-        assert_eq!(weather_data.name, "Test City");
-        assert!(weather_data.weather[0].description.contains("mock"));
     }
 
     /// Verifies that `aggregate_daily` buckets 3-hourly entries by UTC calendar
@@ -282,28 +267,6 @@ mod tests {
         assert_eq!(day2.temp_max, 20.0);
         assert_eq!(day2.description, "Clear description");
         assert_eq!(day2.pop, 0.5);
-    }
-
-    /// Verifies that `GoogleWeatherProvider::get_forecast` returns an empty
-    /// placeholder rather than fabricated forecast data.
-    #[tokio::test]
-    async fn test_google_weather_forecast_is_empty() {
-        use crate::weather_api::google_weather_api::GoogleWeatherProvider;
-        use crate::weather_api::weather_provider::WeatherProvider;
-
-        let provider = GoogleWeatherProvider::new();
-        let location = LocationConfig {
-            city: "Test City".to_string(),
-            state: "TS".to_string(),
-            country: "TC".to_string(),
-        };
-
-        let result = provider.get_forecast(&location).await;
-        assert!(result.is_ok());
-
-        let forecast = result.unwrap();
-        assert_eq!(forecast.location_name, "Test City");
-        assert!(forecast.days.is_empty());
     }
 
     /// Verifies the hand-authored Lottie assets under `assets/lottie/` are

--- a/src/ui/forecast_row.rs
+++ b/src/ui/forecast_row.rs
@@ -3,9 +3,11 @@
 //! A horizontally-scrollable row of day cards (icon + hi/lo + short description),
 //! rendered below the current-conditions card on the main screen. Omitted entirely
 //! while loading or on error (either already communicated elsewhere in the UI),
-//! but a provider with no real forecast integration (e.g. the Google Weather
-//! mock) gets an explicit muted hint rather than the row just silently
-//! vanishing, which otherwise reads as a bug rather than a provider limitation.
+//! but a provider with no real forecast integration gets an explicit muted
+//! hint rather than the row just silently vanishing, which otherwise reads
+//! as a bug rather than a provider limitation. Both current providers
+//! (OpenWeather, Google Weather) return real forecasts today; this path
+//! exists for future providers that might not.
 
 use iced::widget::{column, container, mouse_area, responsive, row, scrollable, text};
 use iced::{Alignment, Element, Font, Length, font};

--- a/src/ui/main_screen.rs
+++ b/src/ui/main_screen.rs
@@ -10,6 +10,7 @@ use iced::widget::{button, column, container, row, scrollable, space, text, tool
 use iced::{Alignment, Color, Element, Font, Length, font};
 
 use crate::app::{AppState, ForecastStatus, Message, WeatherStatus};
+use crate::config::WeatherApiProvider;
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
     speed_to_display, speed_unit, unit_symbol,
@@ -163,8 +164,48 @@ pub fn view(state: &AppState) -> Element<'_, Message> {
     // or a display with unusual scaling), scroll instead of letting iced
     // silently squeeze fixed-size widgets like the animated icons into
     // whatever space is left -- that squeeze is what actually distorted them,
-    // not the icons' own sizing.
-    scrollable(layout).height(Length::Fill).into()
+    // not the icons' own sizing. The provider ribbon sits outside the
+    // scrollable, as a sibling `column` entry, so it stays pinned to the
+    // bottom of the window rather than scrolling away with the content.
+    column![
+        scrollable(layout).height(Length::Fill),
+        provider_ribbon(&state.config.weather_provider),
+    ]
+    .into()
+}
+
+/// A thin footer strip naming whichever provider is currently powering the
+/// displayed data, linked to that provider's own homepage -- config-driven
+/// rather than tracked per-fetch, since a fetch always uses whatever
+/// provider is currently configured (there's no per-request override). Uses
+/// its own display label rather than `WeatherApiProvider`'s `Display` impl
+/// (which renders "OpenWeather" as one word, matching the service's own
+/// branding elsewhere, e.g. Preferences).
+fn provider_ribbon(provider: &WeatherApiProvider) -> Element<'_, Message> {
+    let (label, homepage) = match provider {
+        WeatherApiProvider::OpenWeather => ("Open Weather", "https://openweathermap.org/"),
+        WeatherApiProvider::GoogleWeather => (
+            "Google Weather",
+            "https://mapsplatform.google.com/maps-products/weather/",
+        ),
+    };
+
+    container(
+        row![
+            space::horizontal(),
+            text("Powered by").size(11).style(style::muted),
+            button(text(label).size(11))
+                .on_press(Message::OpenUrl(homepage.to_string()))
+                .style(style::link_button)
+                .padding(0),
+        ]
+        .spacing(4)
+        .align_y(Alignment::Center),
+    )
+    .width(Length::Fill)
+    .padding(6)
+    .style(style::ribbon)
+    .into()
 }
 
 /// The left-hand hero: icon, location, big temperature, and a short

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -75,10 +75,9 @@ impl State {
         if self.country_input.trim().is_empty() {
             errors.push("Country is required.".to_string());
         }
-        // Only OpenWeather actually needs a token; the Google Weather mock
-        // provider works with none (see WeatherProvider::requires_api_key).
-        if self.provider == WeatherApiProvider::OpenWeather && self.token_input.trim().is_empty() {
-            errors.push("API Token is required for OpenWeather.".to_string());
+        // Both providers require a token (see WeatherProvider::requires_api_key).
+        if self.token_input.trim().is_empty() {
+            errors.push(format!("API Token is required for {}.", self.provider));
         }
 
         errors

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -69,6 +69,24 @@ pub fn day_card(theme: &Theme) -> container::Style {
     }
 }
 
+/// The thin footer ribbon naming the currently-active weather provider --
+/// pinned to the bottom of the main window (see `main_screen::view`),
+/// deliberately flatter/lower-contrast than `panel`/`day_card` since it's an
+/// attribution strip, not another content card.
+pub fn ribbon(theme: &Theme) -> container::Style {
+    let palette = theme.extended_palette();
+
+    container::Style {
+        background: Some(Background::Color(palette.background.weak.color)),
+        border: Border {
+            color: palette.background.strong.color,
+            width: 1.0,
+            radius: 0.0.into(),
+        },
+        ..container::Style::default()
+    }
+}
+
 /// Today's forecast card: same shape as `day_card`, but with an accent
 /// border so it stands out at a glance from the other four days.
 pub fn day_card_today(theme: &Theme) -> container::Style {

--- a/src/weather_api/google_weather_api.rs
+++ b/src/weather_api/google_weather_api.rs
@@ -1,119 +1,706 @@
-//! # Google Weather API Provider (Mockup)
+//! # Google Weather API Provider
 //!
-//! This module provides a mock implementation of a `WeatherProvider` for the
-//! "Google Weather" API. It is designed for development, testing, and
-//! demonstration purposes.
+//! Real implementation of `WeatherProvider` against Google Maps Platform's
+//! Weather API (`https://weather.googleapis.com`). See
+//! `docs/GOOGLE_WEATHER_API.md` for the full endpoint/response research this
+//! module is based on.
 //!
-//! Instead of making a real network request to a Google Weather service, this
-//! provider simulates an API call by introducing a short delay and then returning
-//! hardcoded, sample weather data. This allows for UI development and testing
-//! of the provider abstraction layer without needing a network connection or a
-//! valid API key.
+//! Two things this API doesn't provide that `openweather_api.rs`'s single
+//! endpoint does:
+//!
+//! - **Geocoding.** Google's endpoints take `location.latitude`/
+//!   `location.longitude` only -- there's no city-name lookup. Resolved here
+//!   via the free, keyless Open-Meteo Geocoding API rather than Google's own
+//!   (billable, separately-enabled) Geocoding API, so this provider stays
+//!   independent of any other provider's key and doesn't require enabling a
+//!   second Google Cloud API.
+//! - **Sunrise/sunset in `currentConditions`.** Those live in the daily
+//!   forecast's `sunEvents` instead, so `get_weather` makes a supplementary
+//!   `forecast/days:lookup?days=1` call purely to read today's sun events
+//!   and min/max temperatures.
+//!
+//! Timestamps come back as RFC 3339 UTC strings plus an IANA zone id (e.g.
+//! `"America/Los_Angeles"`), but the shared `ApiResponse` shape expects a
+//! Unix timestamp and a UTC-offset-in-seconds (see `Sys`/`ApiResponse::
+//! timezone`). The `jiff` crate resolves the correct DST-aware offset for
+//! that zone id at that instant.
 
 use crate::config::LocationConfig;
-use crate::weather_api::forecast::ForecastResponse;
-use crate::weather_api::openweather_api::{ApiError, ApiResponse, Main, Sys, Weather, Wind};
+use crate::weather_api::forecast::{ForecastDay, ForecastResponse};
+use crate::weather_api::openweather_api::{
+    ApiError, ApiResponse, Main, Sys, Weather, Wind, get_weather_symbol,
+};
 use crate::weather_api::weather_provider::WeatherProvider;
 use async_trait::async_trait;
+use serde::Deserialize;
 
-/// A mock implementation of the `WeatherProvider` trait for Google Weather.
-///
-/// This provider returns sample weather data and is intended for demonstration purposes.
-pub struct GoogleWeatherProvider;
+const WEATHER_API_BASE: &str = "https://weather.googleapis.com/v1";
+const GEOCODING_API_BASE: &str = "https://geocoding-api.open-meteo.com/v1/search";
+/// Matches `forecast::MAX_FORECAST_DAYS` -- no point requesting more days
+/// from Google than the UI will ever show.
+const FORECAST_DAYS: u8 = 5;
 
-impl Default for GoogleWeatherProvider {
-    fn default() -> Self {
-        Self::new()
+// --- Open-Meteo geocoding -----------------------------------------------
+
+#[derive(Deserialize, Debug)]
+struct GeocodeResult {
+    latitude: f64,
+    longitude: f64,
+    /// Full admin-1 (state/province) name, e.g. "Illinois" -- present when
+    /// the location has one. Used to disambiguate same-named cities in
+    /// different states/provinces (e.g. Peoria, IL vs. Peoria, AZ), since
+    /// Open-Meteo's `name` search has no state/province filter parameter.
+    #[serde(default)]
+    admin1: Option<String>,
+}
+
+/// Open-Meteo omits the `results` key entirely (rather than returning `[]`)
+/// when nothing matches, hence `#[serde(default)]`.
+#[derive(Deserialize, Debug, Default)]
+struct GeocodeResponse {
+    #[serde(default)]
+    results: Vec<GeocodeResult>,
+}
+
+/// U.S. postal abbreviation -> full state name, used only to translate a
+/// `LocationConfig.state` like `"IL"` into the `"Illinois"` Open-Meteo
+/// returns as `admin1` -- `LocationConfig.state` is otherwise passed through
+/// as-is (e.g. for non-US provinces already given in full, like "Ontario").
+const US_STATE_ABBREVIATIONS: &[(&str, &str)] = &[
+    ("AL", "Alabama"),
+    ("AK", "Alaska"),
+    ("AZ", "Arizona"),
+    ("AR", "Arkansas"),
+    ("CA", "California"),
+    ("CO", "Colorado"),
+    ("CT", "Connecticut"),
+    ("DE", "Delaware"),
+    ("FL", "Florida"),
+    ("GA", "Georgia"),
+    ("HI", "Hawaii"),
+    ("ID", "Idaho"),
+    ("IL", "Illinois"),
+    ("IN", "Indiana"),
+    ("IA", "Iowa"),
+    ("KS", "Kansas"),
+    ("KY", "Kentucky"),
+    ("LA", "Louisiana"),
+    ("ME", "Maine"),
+    ("MD", "Maryland"),
+    ("MA", "Massachusetts"),
+    ("MI", "Michigan"),
+    ("MN", "Minnesota"),
+    ("MS", "Mississippi"),
+    ("MO", "Missouri"),
+    ("MT", "Montana"),
+    ("NE", "Nebraska"),
+    ("NV", "Nevada"),
+    ("NH", "New Hampshire"),
+    ("NJ", "New Jersey"),
+    ("NM", "New Mexico"),
+    ("NY", "New York"),
+    ("NC", "North Carolina"),
+    ("ND", "North Dakota"),
+    ("OH", "Ohio"),
+    ("OK", "Oklahoma"),
+    ("OR", "Oregon"),
+    ("PA", "Pennsylvania"),
+    ("RI", "Rhode Island"),
+    ("SC", "South Carolina"),
+    ("SD", "South Dakota"),
+    ("TN", "Tennessee"),
+    ("TX", "Texas"),
+    ("UT", "Utah"),
+    ("VT", "Vermont"),
+    ("VA", "Virginia"),
+    ("WA", "Washington"),
+    ("WV", "West Virginia"),
+    ("WI", "Wisconsin"),
+    ("WY", "Wyoming"),
+    ("DC", "District of Columbia"),
+];
+
+/// Resolves a `LocationConfig` to coordinates via the free, keyless
+/// Open-Meteo Geocoding API. Requests several candidates and, when a state/
+/// province was given, prefers the one whose `admin1` matches it -- plain
+/// `name`-only search can't tell "Peoria, IL" from "Peoria, AZ" apart, and
+/// picking the wrong one silently returns a real, plausible-looking, but
+/// entirely wrong forecast.
+async fn geocode(location: &LocationConfig) -> Result<(f64, f64), ApiError> {
+    let client = reqwest::Client::new();
+    let mut query = vec![
+        ("name", location.city.clone()),
+        ("count", "10".to_string()),
+        ("language", "en".to_string()),
+        ("format", "json".to_string()),
+    ];
+    if !location.country.is_empty() {
+        query.push(("countryCode", location.country.clone()));
+    }
+
+    let response = client
+        .get(GEOCODING_API_BASE)
+        .query(&query)
+        .send()
+        .await
+        .map_err(ApiError::RequestFailed)?;
+
+    let parsed = response
+        .json::<GeocodeResponse>()
+        .await
+        .map_err(|_| ApiError::InvalidResponse)?;
+
+    let target_state = location.state.trim();
+    let target_state = US_STATE_ABBREVIATIONS
+        .iter()
+        .find(|(abbr, _)| abbr.eq_ignore_ascii_case(target_state))
+        .map(|(_, full)| *full)
+        .unwrap_or(target_state);
+
+    let results = parsed.results;
+    if !target_state.is_empty()
+        && let Some(matched) = results.iter().find(|r| {
+            r.admin1
+                .as_deref()
+                .is_some_and(|admin1| admin1.eq_ignore_ascii_case(target_state))
+        })
+    {
+        return Ok((matched.latitude, matched.longitude));
+    }
+
+    results
+        .into_iter()
+        .next()
+        .map(|r| (r.latitude, r.longitude))
+        .ok_or(ApiError::CityNotFound)
+}
+
+// --- Google Weather API response types ----------------------------------
+
+#[derive(Deserialize, Debug)]
+struct GTimeZone {
+    id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct GDescription {
+    text: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct GWeatherCondition {
+    description: GDescription,
+    #[serde(rename = "type")]
+    condition_type: String,
+}
+
+/// Shared shape for `temperature`/`feelsLikeTemperature`/`maxTemperature`/etc.
+#[derive(Deserialize, Debug)]
+struct GDegrees {
+    degrees: f64,
+}
+
+#[derive(Deserialize, Debug)]
+struct GWindDirection {
+    degrees: i64,
+}
+
+#[derive(Deserialize, Debug)]
+struct GWindSpeed {
+    value: f64,
+}
+
+#[derive(Deserialize, Debug)]
+struct GWind {
+    direction: GWindDirection,
+    speed: GWindSpeed,
+}
+
+#[derive(Deserialize, Debug)]
+struct GVisibility {
+    distance: f64,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GAirPressure {
+    mean_sea_level_millibars: f64,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct CurrentConditionsResponse {
+    weather_condition: GWeatherCondition,
+    temperature: GDegrees,
+    feels_like_temperature: GDegrees,
+    relative_humidity: i64,
+    wind: GWind,
+    visibility: GVisibility,
+    air_pressure: GAirPressure,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct SunEvents {
+    sunrise_time: String,
+    sunset_time: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DisplayDate {
+    year: i32,
+    month: u32,
+    day: u32,
+}
+
+#[derive(Deserialize, Debug)]
+struct PrecipProbability {
+    percent: i64,
+}
+
+#[derive(Deserialize, Debug)]
+struct GPrecipitation {
+    probability: PrecipProbability,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct DayNightForecast {
+    weather_condition: GWeatherCondition,
+    relative_humidity: i64,
+    wind: GWind,
+    precipitation: GPrecipitation,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ForecastDayItem {
+    display_date: DisplayDate,
+    max_temperature: GDegrees,
+    min_temperature: GDegrees,
+    feels_like_max_temperature: GDegrees,
+    sun_events: SunEvents,
+    daytime_forecast: DayNightForecast,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ForecastDaysResponse {
+    forecast_days: Vec<ForecastDayItem>,
+    time_zone: GTimeZone,
+}
+
+// --- Unit conversions -----------------------------------------------------
+// Google's METRIC unit system (requested explicitly below) returns wind
+// speed in km/h and visibility in km; the shared `Wind`/visibility fields
+// elsewhere in this codebase are documented as m/s and meters respectively
+// (see `openweather_api::Wind`/`ApiResponse::visibility`).
+
+fn kmh_to_mps(kmh: f64) -> f64 {
+    kmh / 3.6
+}
+
+fn km_to_meters(km: f64) -> f64 {
+    km * 1000.0
+}
+
+/// Maps Google's `WeatherCondition.Type` enum values onto the OpenWeatherMap
+/// "main" condition strings `get_weather_symbol` already knows how to turn
+/// into an icon -- reuses that lookup rather than adding a parallel symbol
+/// table. Unrecognized/unspecified types fall through to `""`, which
+/// `get_weather_symbol` maps to `WeatherSymbol::Default`.
+fn google_condition_to_owm_main(condition_type: &str) -> &'static str {
+    match condition_type {
+        "CLEAR" | "MOSTLY_CLEAR" => "Clear",
+        "PARTLY_CLOUDY" | "MOSTLY_CLOUDY" | "CLOUDY" | "WINDY" => "Clouds",
+        "THUNDERSTORM"
+        | "THUNDERSHOWER"
+        | "LIGHT_THUNDERSTORM_RAIN"
+        | "SCATTERED_THUNDERSTORMS"
+        | "HEAVY_THUNDERSTORM" => "Thunderstorm",
+        "LIGHT_SNOW_SHOWERS"
+        | "CHANCE_OF_SNOW_SHOWERS"
+        | "SCATTERED_SNOW_SHOWERS"
+        | "SNOW_SHOWERS"
+        | "HEAVY_SNOW_SHOWERS"
+        | "LIGHT_TO_MODERATE_SNOW"
+        | "MODERATE_TO_HEAVY_SNOW"
+        | "SNOW"
+        | "LIGHT_SNOW"
+        | "HEAVY_SNOW"
+        | "SNOWSTORM"
+        | "SNOW_PERIODICALLY_HEAVY"
+        | "HEAVY_SNOW_STORM"
+        | "BLOWING_SNOW"
+        | "RAIN_AND_SNOW"
+        | "HAIL"
+        | "HAIL_SHOWERS" => "Snow",
+        "WIND_AND_RAIN"
+        | "LIGHT_RAIN_SHOWERS"
+        | "CHANCE_OF_SHOWERS"
+        | "SCATTERED_SHOWERS"
+        | "RAIN_SHOWERS"
+        | "HEAVY_RAIN_SHOWERS"
+        | "LIGHT_TO_MODERATE_RAIN"
+        | "MODERATE_TO_HEAVY_RAIN"
+        | "RAIN"
+        | "LIGHT_RAIN"
+        | "HEAVY_RAIN"
+        | "RAIN_PERIODICALLY_HEAVY" => "Rain",
+        _ => "",
     }
 }
 
+/// Parses an RFC 3339 UTC timestamp (as Google returns for `sunriseTime`/
+/// `sunsetTime`) into a Unix epoch and the UTC offset (seconds) that
+/// `iana_zone_id` observes at that instant -- the offset varies with DST, so
+/// this can't be a fixed lookup table. Falls back to `(0, 0)` on any parse
+/// failure rather than failing the whole fetch over a display-only field.
+fn resolve_epoch_and_offset(rfc3339: &str, iana_zone_id: &str) -> (i64, i64) {
+    let Ok(timestamp) = rfc3339.parse::<jiff::Timestamp>() else {
+        log::warn!("Failed to parse Google Weather timestamp: {rfc3339}");
+        return (0, 0);
+    };
+    let epoch = timestamp.as_second();
+    let offset = match timestamp.in_tz(iana_zone_id) {
+        Ok(zoned) => zoned.offset().seconds() as i64,
+        Err(e) => {
+            log::warn!("Failed to resolve timezone {iana_zone_id}: {e}");
+            0
+        }
+    };
+    (epoch, offset)
+}
+
+async fn fetch_current_conditions(
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+) -> Result<CurrentConditionsResponse, ApiError> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("{WEATHER_API_BASE}/currentConditions:lookup"))
+        .query(&[
+            ("key", api_key.to_string()),
+            ("location.latitude", lat.to_string()),
+            ("location.longitude", lon.to_string()),
+            ("unitsSystem", "METRIC".to_string()),
+        ])
+        .send()
+        .await
+        .map_err(ApiError::RequestFailed)?;
+
+    if !response.status().is_success() {
+        log::error!(
+            "Google currentConditions request failed: {}",
+            response.status()
+        );
+        return Err(ApiError::CityNotFound);
+    }
+
+    response
+        .json::<CurrentConditionsResponse>()
+        .await
+        .map_err(|e| {
+            log::error!("Failed to parse Google currentConditions response: {e}");
+            ApiError::InvalidResponse
+        })
+}
+
+async fn fetch_forecast_days(
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+    days: u8,
+) -> Result<ForecastDaysResponse, ApiError> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("{WEATHER_API_BASE}/forecast/days:lookup"))
+        .query(&[
+            ("key", api_key.to_string()),
+            ("location.latitude", lat.to_string()),
+            ("location.longitude", lon.to_string()),
+            ("unitsSystem", "METRIC".to_string()),
+            ("days", days.to_string()),
+        ])
+        .send()
+        .await
+        .map_err(ApiError::RequestFailed)?;
+
+    if !response.status().is_success() {
+        log::error!("Google forecast/days request failed: {}", response.status());
+        return Err(ApiError::CityNotFound);
+    }
+
+    response.json::<ForecastDaysResponse>().await.map_err(|e| {
+        log::error!("Failed to parse Google forecast/days response: {e}");
+        ApiError::InvalidResponse
+    })
+}
+
+fn map_forecast_day(item: &ForecastDayItem) -> ForecastDay {
+    let day = &item.daytime_forecast;
+    ForecastDay {
+        date: format!(
+            "{:04}-{:02}-{:02}",
+            item.display_date.year, item.display_date.month, item.display_date.day
+        ),
+        temp_min: item.min_temperature.degrees,
+        temp_max: item.max_temperature.degrees,
+        description: day.weather_condition.description.text.clone(),
+        symbol: get_weather_symbol(google_condition_to_owm_main(
+            &day.weather_condition.condition_type,
+        )),
+        feels_like: item.feels_like_max_temperature.degrees,
+        humidity: day.relative_humidity,
+        wind_speed: kmh_to_mps(day.wind.speed.value),
+        wind_deg: day.wind.direction.degrees,
+        // Google's per-day forecast doesn't return barometric pressure or
+        // visibility -- both fields are `#[allow(dead_code)]` on
+        // `ForecastDay` today (nothing reads them yet), so this isn't a
+        // display regression.
+        pressure: 0,
+        visibility: 0,
+        pop: day.precipitation.probability.percent as f64 / 100.0,
+    }
+}
+
+/// A real implementation of the `WeatherProvider` trait for Google Maps
+/// Platform's Weather API.
+pub struct GoogleWeatherProvider {
+    api_key: String,
+}
+
 impl GoogleWeatherProvider {
-    /// Creates a new instance of the `GoogleWeatherProvider`.
-    pub fn new() -> Self {
-        Self
+    /// Creates a new `GoogleWeatherProvider` with the given Google Cloud API
+    /// key (must have the Weather API enabled on its project).
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
     }
 }
 
 #[async_trait]
 impl WeatherProvider for GoogleWeatherProvider {
-    /// Simulates fetching weather data for a given location.
-    ///
-    /// This is a mock implementation that introduces a 500ms delay to simulate
-    /// network latency and then returns a hardcoded `ApiResponse` with sample
-    /// weather data. The city name in the response is taken from the input `location`.
-    ///
-    /// # Arguments
-    ///
-    /// * `location` - A reference to the `LocationConfig` for which to generate mock weather data.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` containing a mock `ApiResponse` on success. This implementation never returns an `ApiError`.
     async fn get_weather(&self, location: &LocationConfig) -> Result<ApiResponse, ApiError> {
-        log::info!(
-            "Google Weather API (mockup) called for location: {}, {}, {}",
-            location.city,
-            location.state,
-            location.country
-        );
+        let (lat, lon) = geocode(location).await?;
 
-        // Simulate API delay
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        let current = fetch_current_conditions(&self.api_key, lat, lon).await?;
+        // Sunrise/sunset and today's min/max only come from the daily
+        // forecast, not currentConditions -- see the module doc.
+        let forecast = fetch_forecast_days(&self.api_key, lat, lon, 1).await?;
+        let today = forecast
+            .forecast_days
+            .first()
+            .ok_or(ApiError::InvalidResponse)?;
 
-        // Return mock weather data
-        let mock_response = ApiResponse {
+        let (sunrise, sunrise_offset) =
+            resolve_epoch_and_offset(&today.sun_events.sunrise_time, &forecast.time_zone.id);
+        let (sunset, _) =
+            resolve_epoch_and_offset(&today.sun_events.sunset_time, &forecast.time_zone.id);
+
+        Ok(ApiResponse {
             weather: vec![Weather {
-                main: "Clear".to_string(),
-                description: "clear sky (mock data)".to_string(),
+                main: google_condition_to_owm_main(&current.weather_condition.condition_type)
+                    .to_string(),
+                description: current.weather_condition.description.text.clone(),
             }],
             main: Main {
-                temp: 22.5,
-                feels_like: 22.0,
-                temp_min: 19.0,
-                temp_max: 25.0,
-                pressure: 1015,
-                humidity: 65,
+                temp: current.temperature.degrees,
+                feels_like: current.feels_like_temperature.degrees,
+                temp_min: today.min_temperature.degrees,
+                temp_max: today.max_temperature.degrees,
+                pressure: current.air_pressure.mean_sea_level_millibars.round() as i64,
+                humidity: current.relative_humidity,
             },
             wind: Wind {
-                speed: 3.6,
-                deg: 210,
+                speed: kmh_to_mps(current.wind.speed.value),
+                deg: current.wind.direction.degrees,
             },
-            visibility: 10000,
-            sys: Sys {
-                sunrise: 1_700_000_000,
-                sunset: 1_700_040_000,
-            },
-            timezone: 0,
+            visibility: km_to_meters(current.visibility.distance) as i64,
+            sys: Sys { sunrise, sunset },
+            timezone: sunrise_offset,
             name: location.city.clone(),
-        };
-
-        log::info!("Google Weather API (mockup) returning mock data");
-        Ok(mock_response)
-    }
-
-    /// Returns an empty placeholder forecast.
-    ///
-    /// There is no real Google Weather forecast integration; rather than fabricate
-    /// fake forecast days, this intentionally returns an empty `days` list so the
-    /// UI can omit the forecast row entirely for this provider.
-    async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError> {
-        log::info!(
-            "Google Weather API (mockup) get_forecast called for {}: no forecast data available",
-            location.city
-        );
-        Ok(ForecastResponse {
-            location_name: location.city.clone(),
-            days: vec![],
         })
     }
 
-    /// Returns the display name of the weather provider.
-    fn name(&self) -> &'static str {
-        "Google Weather (Mockup)"
+    async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError> {
+        let (lat, lon) = geocode(location).await?;
+        let forecast = fetch_forecast_days(&self.api_key, lat, lon, FORECAST_DAYS).await?;
+
+        Ok(ForecastResponse {
+            location_name: location.city.clone(),
+            days: forecast
+                .forecast_days
+                .iter()
+                .map(map_forecast_day)
+                .collect(),
+        })
     }
 
-    /// Returns `false` as this mock provider does not require an API key.
+    fn name(&self) -> &'static str {
+        "Google Weather"
+    }
+
     fn requires_api_key(&self) -> bool {
-        false
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_condition_mapping() {
+        assert_eq!(google_condition_to_owm_main("CLEAR"), "Clear");
+        assert_eq!(google_condition_to_owm_main("MOSTLY_CLEAR"), "Clear");
+        assert_eq!(google_condition_to_owm_main("CLOUDY"), "Clouds");
+        assert_eq!(google_condition_to_owm_main("HEAVY_RAIN"), "Rain");
+        assert_eq!(google_condition_to_owm_main("SNOWSTORM"), "Snow");
+        assert_eq!(
+            google_condition_to_owm_main("HEAVY_THUNDERSTORM"),
+            "Thunderstorm"
+        );
+        assert_eq!(google_condition_to_owm_main("SOMETHING_UNKNOWN"), "");
+    }
+
+    #[test]
+    fn test_unit_conversions() {
+        assert!((kmh_to_mps(3.6) - 1.0).abs() < 1e-9);
+        assert!((km_to_meters(10.0) - 10_000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_geocode_response_with_results() {
+        let json = r#"{"results":[{"latitude":37.422,"longitude":-122.0841}]}"#;
+        let parsed: GeocodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.results.len(), 1);
+        assert_eq!(parsed.results[0].latitude, 37.422);
+    }
+
+    #[test]
+    fn test_geocode_response_missing_results_key() {
+        // Open-Meteo omits `results` entirely (rather than `[]`) when
+        // nothing matches -- this must not fail to deserialize.
+        let json = r#"{"generationtime_ms":0.5}"#;
+        let parsed: GeocodeResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.results.is_empty());
+    }
+
+    /// Regression test for a real bug caught by the live smoke test: with
+    /// only `count=1` and no state disambiguation, "Peoria" resolved to
+    /// Peoria, AZ instead of Peoria, IL. Verifies the `admin1`-matching
+    /// selects the right same-named city out of several candidates.
+    #[test]
+    fn test_geocode_disambiguates_same_named_city_by_state() {
+        let json = r#"{"results":[
+            {"latitude":33.5806,"longitude":-112.2374,"admin1":"Arizona"},
+            {"latitude":40.6936,"longitude":-89.5890,"admin1":"Illinois"}
+        ]}"#;
+        let parsed: GeocodeResponse = serde_json::from_str(json).unwrap();
+        let location = LocationConfig {
+            city: "Peoria".to_string(),
+            state: "IL".to_string(),
+            country: "US".to_string(),
+        };
+        let target_state = US_STATE_ABBREVIATIONS
+            .iter()
+            .find(|(abbr, _)| abbr.eq_ignore_ascii_case(&location.state))
+            .map(|(_, full)| *full)
+            .unwrap();
+        assert_eq!(target_state, "Illinois");
+        let matched = parsed
+            .results
+            .iter()
+            .find(|r| r.admin1.as_deref() == Some(target_state))
+            .unwrap();
+        assert_eq!((matched.latitude, matched.longitude), (40.6936, -89.5890));
+    }
+
+    #[test]
+    fn test_current_conditions_deserialize_and_map() {
+        let json = r#"{
+            "weatherCondition": {
+                "iconBaseUri": "https://maps.gstatic.com/weather/v1/sunny",
+                "description": { "text": "Sunny", "languageCode": "en" },
+                "type": "CLEAR"
+            },
+            "temperature": { "degrees": 22.5, "unit": "CELSIUS" },
+            "feelsLikeTemperature": { "degrees": 22.0, "unit": "CELSIUS" },
+            "relativeHumidity": 65,
+            "wind": {
+                "direction": { "degrees": 210, "cardinal": "SSW" },
+                "speed": { "value": 12.96, "unit": "KILOMETERS_PER_HOUR" },
+                "gust": { "value": 20.0, "unit": "KILOMETERS_PER_HOUR" }
+            },
+            "visibility": { "distance": 10.0, "unit": "KILOMETERS" },
+            "airPressure": { "meanSeaLevelMillibars": 1015.0 },
+            "cloudCover": 0
+        }"#;
+        let parsed: CurrentConditionsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.weather_condition.condition_type, "CLEAR");
+        assert_eq!(parsed.temperature.degrees, 22.5);
+        assert_eq!(parsed.relative_humidity, 65);
+        assert!((kmh_to_mps(parsed.wind.speed.value) - 3.6).abs() < 1e-6);
+        assert_eq!(parsed.air_pressure.mean_sea_level_millibars, 1015.0);
+    }
+
+    #[test]
+    fn test_forecast_days_deserialize_and_map() {
+        let json = r#"{
+            "forecastDays": [
+                {
+                    "displayDate": { "year": 2026, "month": 7, "day": 4 },
+                    "maxTemperature": { "degrees": 28.0, "unit": "CELSIUS" },
+                    "minTemperature": { "degrees": 16.0, "unit": "CELSIUS" },
+                    "feelsLikeMaxTemperature": { "degrees": 29.0, "unit": "CELSIUS" },
+                    "sunEvents": {
+                        "sunriseTime": "2026-07-04T11:00:00Z",
+                        "sunsetTime": "2026-07-05T02:00:00Z"
+                    },
+                    "daytimeForecast": {
+                        "weatherCondition": {
+                            "iconBaseUri": "https://maps.gstatic.com/weather/v1/cloudy",
+                            "description": { "text": "Cloudy", "languageCode": "en" },
+                            "type": "CLOUDY"
+                        },
+                        "relativeHumidity": 40,
+                        "wind": {
+                            "direction": { "degrees": 90, "cardinal": "E" },
+                            "speed": { "value": 7.2, "unit": "KILOMETERS_PER_HOUR" },
+                            "gust": { "value": 10.0, "unit": "KILOMETERS_PER_HOUR" }
+                        },
+                        "precipitation": {
+                            "probability": { "percent": 30, "type": "RAIN" }
+                        }
+                    }
+                }
+            ],
+            "timeZone": { "id": "America/Chicago" }
+        }"#;
+        let parsed: ForecastDaysResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.time_zone.id, "America/Chicago");
+        let day = map_forecast_day(&parsed.forecast_days[0]);
+        assert_eq!(day.date, "2026-07-04");
+        assert_eq!(day.temp_max, 28.0);
+        assert_eq!(day.temp_min, 16.0);
+        assert_eq!(day.description, "Cloudy");
+        assert!((day.wind_speed - 2.0).abs() < 1e-6);
+        assert!((day.pop - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_resolve_epoch_and_offset_valid() {
+        let (epoch, offset) = resolve_epoch_and_offset("2026-07-04T11:00:00Z", "America/Chicago");
+        assert!(epoch > 0);
+        // America/Chicago is UTC-5 during summer (CDT).
+        assert_eq!(offset, -5 * 3600);
+    }
+
+    #[test]
+    fn test_resolve_epoch_and_offset_invalid_falls_back() {
+        let (epoch, offset) = resolve_epoch_and_offset("not-a-timestamp", "America/Chicago");
+        assert_eq!(epoch, 0);
+        assert_eq!(offset, 0);
     }
 }

--- a/src/weather_api/weather_provider.rs
+++ b/src/weather_api/weather_provider.rs
@@ -38,9 +38,7 @@ pub trait WeatherProvider {
     /// Fetches a multi-day forecast for a given location.
     ///
     /// # Errors
-    /// Returns an `ApiError` if the data cannot be fetched. Providers without a real
-    /// forecast integration (e.g. the Google Weather mock) may return an empty
-    /// `ForecastResponse` rather than an error.
+    /// Returns an `ApiError` if the data cannot be fetched.
     async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError>;
 
     /// Returns the display name of the weather provider (e.g., "OpenWeather").
@@ -78,9 +76,12 @@ impl WeatherProviderFactory {
                     token,
                 )))
             }
-            WeatherApiProvider::GoogleWeather => Ok(Box::new(
-                super::google_weather_api::GoogleWeatherProvider::new(),
-            )),
+            WeatherApiProvider::GoogleWeather => {
+                let token = api_token.ok_or("Google Weather API requires an API token")?;
+                Ok(Box::new(
+                    super::google_weather_api::GoogleWeatherProvider::new(token),
+                ))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded `GoogleWeatherProvider` mock with a real integration against Google Maps Platform's Weather API (`currentConditions:lookup` + `forecast/days:lookup`), closing #35.
- Geocode via the free, keyless Open-Meteo API, disambiguating same-named cities in different states/provinces (e.g. Peoria, IL vs. Peoria, AZ) by `admin1`/state match — a real bug caught while testing against the live API.
- Resolve DST-aware local-time offsets for sunrise/sunset via the new `jiff` dependency, since Google returns UTC timestamps plus an IANA zone id rather than a UTC offset.
- Google Weather now requires an API token (`requires_api_key: true`) and gets its own 15-minute auto-refresh interval, distinct from OpenWeatherMap's 30s, to stay within Google's free-tier call quota.
- Fix `examples/openweather_test.rs`: it used `"UK"` as a country code, which isn't a valid ISO 3166-1 alpha-2 code (`"GB"` is), so OpenWeatherMap's geocoding silently returned zero results. Also added a forecast fetch to match the new Google example's coverage.
- Add a thin attribution ribbon, pinned to the bottom of the main window and right-aligned, naming and linking to whichever provider is currently configured.

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all` (25 tests, incl. new fixture-based Google Weather unit tests — no network/live key needed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Live smoke test against a real Google Cloud API key (`cargo run --example google_weather_test`) — confirmed correct temps, condition, and DST-aware timezone offset for Peoria, IL after the geocoding disambiguation fix
- [x] Live smoke test against a real OpenWeatherMap key (`cargo run --example openweather_test`) — confirmed fixed after the country-code correction
- [x] Visual check of the new ribbon in a running window (blocked in this environment by a real macOS Keychain prompt on boot that I can't interact with on your behalf — worth a quick `cargo run` on your end)