### PR TITLE
ci: restrict triggers to main, release tags, and PRs into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "*" ]
+    branches: [ "main" ]
+    tags:
+      - "v*.*.*"
   pull_request:
-    branches: [ "main", "*" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- CI previously ran on every push and every PR regardless of branch.
- Now runs only on: pushes to `main`, version-tag pushes (`v*.*.*`, matching `release.yml`'s own trigger), and pull requests whose base branch is `main`.
- Cuts out redundant CI runs on arbitrary feature branches before a PR exists against them.

## Test plan
- [x] Validated `.github/workflows/ci.yml` YAML parses correctly
- [ ] Confirm this PR itself triggers CI (base is `main`)