### PR TITLE
Add first-run setup flow + credential-clearing example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,7 +3092,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -3116,6 +3116,16 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b034b578389f89a85c055eacc8d8b368be5f04a6c1b07f672bf3aec21d0ef621"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3148,7 +3158,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -3195,8 +3207,21 @@ checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-contacts",
+ "objc2-contacts 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-contacts 0.3.2",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3338,7 +3363,7 @@ dependencies = [
  "objc2-cloud-kit 0.2.2",
  "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
@@ -3367,7 +3392,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -3402,11 +3427,16 @@ dependencies = [
  "base64",
  "dirs",
  "env_logger",
+ "futures-util",
  "iced",
  "image",
  "jiff",
  "keyring",
  "log",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-location 0.3.2",
+ "objc2-foundation 0.3.2",
  "open",
  "reqwest",
  "rust-embed",
@@ -3416,6 +3446,8 @@ dependencies = [
  "tokio-test",
  "velato",
  "wgpu",
+ "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]
@@ -4953,6 +4985,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6361,6 +6394,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,22 @@ path = "src/main.rs"
 [dev-dependencies]
 tokio-test = "0.4.3"
 
+# OS-native location backends (src/geolocation.rs's `os_location` module) --
+# one per platform, so e.g. a Linux build never pulls in objc2/CoreLocation
+# bindings.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSArray", "NSObject", "NSError"] }
+objc2-core-location = { version = "0.3", features = ["CLLocationManager", "CLLocationManagerDelegate", "CLLocation"] }
+objc2-core-foundation = { version = "0.3", features = ["CFRunLoop", "CFDate"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62", features = ["Devices_Geolocation"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "5", default-features = false, features = ["tokio"] }
+futures-util = "0.3"
+
 [package.metadata.packager]
 product-name = "Open Weather Wizard"
 identifier = "com.arunkumarmourougappane.open-weather-wizard"
@@ -57,3 +73,9 @@ depends = ["libxkbcommon0", "libwayland-client0", "libx11-6", "libxrandr2", "lib
 window-size = { width = 660, height = 400 }
 app-position = { x = 180, y = 170 }
 application-folder-position = { x = 480, y = 170 }
+
+# NSLocationWhenInUseUsageDescription is required for the packaged .app to
+# ever show a location permission prompt (see src/geolocation.rs's macos
+# submodule) -- without it, CoreLocation just denies silently.
+[package.metadata.packager.macos]
+info-plist-path = "packaging/macos/Info.plist"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,13 @@ become the body of the GitHub Release created by
 
 ## Unreleased
 
+**Interface**
+
+- First-run setup: if no config file exists yet, Preferences now opens
+  automatically alongside the main window with a welcome banner and a "Get
+  an API key" link for whichever provider is selected, instead of silently
+  attempting a fetch that's guaranteed to fail with no token configured.
+
 **Providers**
 
 - Google Weather is now a real, live provider (Google Maps Platform's

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,9 +13,11 @@ become the body of the GitHub Release created by
   an API key" link for whichever provider is selected, instead of silently
   attempting a fetch that's guaranteed to fail with no token configured.
 - The location section in Preferences is now labeled "Home" and has a
-  "Detect my location" button that prefills city/state/country from an
-  IP-based lookup — a starting point you can still edit by hand, not a
-  precise GPS location.
+  "Detect my location" button. It now tries your OS's native location
+  service first (macOS/Windows/Linux) for real GPS/Wi-Fi-based accuracy,
+  only falling back to an (inherently less accurate) IP-based lookup if
+  native location isn't available or permitted — either way, it's a
+  starting point you can still edit by hand.
 
 **Providers**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,10 @@ become the body of the GitHub Release created by
   automatically alongside the main window with a welcome banner and a "Get
   an API key" link for whichever provider is selected, instead of silently
   attempting a fetch that's guaranteed to fail with no token configured.
+- The location section in Preferences is now labeled "Home" and has a
+  "Detect my location" button that prefills city/state/country from an
+  IP-based lookup — a starting point you can still edit by hand, not a
+  precise GPS location.
 
 **Providers**
 

--- a/examples/clear_credentials.rs
+++ b/examples/clear_credentials.rs
@@ -1,0 +1,49 @@
+//!
+//! Deletes this app's stored API token from the OS's secure credential store
+//! (macOS Keychain / Windows Credential Manager / Linux Secret Service) --
+//! useful for resetting the app back to a fresh-install state (see the
+//! first-run setup flow, issue #38) or clearing credentials before
+//! uninstalling.
+//!
+//! Unlike the other examples in this crate, this one touches the *real* OS
+//! credential store, not a mock or a remote API -- running it has an actual,
+//! irreversible effect (whichever provider is currently configured will need
+//! its token re-entered in Preferences afterward). It asks for an explicit
+//! "yes" confirmation on stdin before deleting anything.
+//!
+//! ```sh
+//! cargo run --example clear_credentials
+//! ```
+use open_weather_wizard::config::AppConfig;
+use std::io::{self, Write};
+
+fn main() {
+    println!("Clear Stored Credentials");
+    println!("=========================\n");
+    println!(
+        "This will permanently delete the Weather Wizard API token stored in \
+         this OS's secure credential store (macOS Keychain / Windows Credential \
+         Manager / Linux Secret Service). You'll need to re-enter it in \
+         Preferences afterward.\n"
+    );
+
+    print!("Type \"yes\" to continue: ");
+    if io::stdout().flush().is_err() {
+        // Nothing meaningful to do if stdout itself is broken -- fall
+        // through and let the read_line below fail/abort the same way.
+    }
+
+    let mut confirmation = String::new();
+    if io::stdin().read_line(&mut confirmation).is_err() || confirmation.trim() != "yes" {
+        println!("Aborted -- no changes made.");
+        return;
+    }
+
+    // Deleting the token doesn't depend on any other config field --
+    // AppConfig::default() is just a handle to call the method through.
+    let config = AppConfig::default();
+    match config.delete_api_token() {
+        Ok(()) => println!("\n✅ Stored API token deleted."),
+        Err(e) => println!("\n⚠️  Failed to delete API token: {e}"),
+    }
+}

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Open Weather Wizard uses your location to suggest your Home city automatically. You can always enter it by hand instead.</string>
+</dict>
+</plist>

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use iced::widget::Space;
 use iced::{Element, Size, Subscription, Task, Theme, window};
 
-use crate::config::{AppConfig, ConfigManager, WeatherApiProvider};
+use crate::config::{AppConfig, ConfigManager, LocationConfig, WeatherApiProvider};
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
     speed_to_display, speed_unit, unit_symbol,
@@ -151,6 +151,11 @@ pub enum Message {
     /// or index `0` ("Today", redundant with the live current-conditions
     /// view), clears the selection back to live conditions.
     ForecastDaySelected(usize),
+    /// Result of `crate::geolocation::detect_location`, fired by
+    /// `Message::Preferences(preferences::Message::DetectLocationRequested)`.
+    /// Applies to whatever Preferences window is currently open, if any --
+    /// see `update`.
+    LocationDetected(Result<LocationConfig, String>),
 
     Preferences(preferences::Message),
 }
@@ -491,6 +496,41 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
         }
         Message::Preferences(preferences::Message::OpenUrl(url)) => {
             Task::done(Message::OpenUrl(url))
+        }
+        Message::Preferences(preferences::Message::DetectLocationRequested) => {
+            let Some(prefs_state) = state.prefs_state.as_mut() else {
+                return Task::none();
+            };
+            prefs_state.is_detecting_location = true;
+            prefs_state.location_detection_error = None;
+            Task::perform(
+                crate::geolocation::detect_location(),
+                Message::LocationDetected,
+            )
+        }
+        Message::LocationDetected(result) => {
+            // The user may have already closed Preferences (or it was never
+            // open outside first-run) by the time this async lookup
+            // resolves -- nothing to apply the result to in that case.
+            let Some(prefs_state) = state.prefs_state.as_mut() else {
+                return Task::none();
+            };
+            prefs_state.is_detecting_location = false;
+            match result {
+                Ok(location) => {
+                    prefs_state.city_input = location.city;
+                    prefs_state.state_input = location.state;
+                    prefs_state.country_input = location.country;
+                }
+                Err(e) => {
+                    log::warn!("Location detection failed: {e}");
+                    prefs_state.location_detection_error = Some(
+                        "Couldn't detect your location automatically -- enter it manually."
+                            .to_string(),
+                    );
+                }
+            }
+            Task::none()
         }
         Message::Preferences(sub_message) => {
             if let Some(prefs_state) = state.prefs_state.as_mut() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -127,6 +127,12 @@ pub struct AppState {
     prefs_window: Option<window::Id>,
     prefs_state: Option<preferences::State>,
     about_window: Option<window::Id>,
+    /// Whether the Preferences window currently open (if any) was opened
+    /// automatically because no config file existed at boot -- read by
+    /// `title()` to swap in a welcome message, and cleared once that
+    /// window's Save/Cancel resolves it (see `update`) so later manual
+    /// reopens via the toolbar never show first-run copy.
+    is_first_run: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -245,20 +251,49 @@ fn note_forecast_transitions(
     }
 }
 
+/// The Preferences window's fixed size/icon -- shared by `boot`'s first-run
+/// auto-open and `Message::OpenPreferences`'s manual one, so the two open
+/// paths can never drift apart.
+fn preferences_window_settings() -> window::Settings {
+    window::Settings {
+        size: Size::new(520.0, 560.0),
+        min_size: Some(PREFERENCES_WINDOW_MIN_SIZE),
+        icon: crate::ui::icons::load_window_icon("icon/icon.png"),
+        ..window::Settings::default()
+    }
+}
+
 /// Boots the application: loads config, opens the main window, and kicks off the
-/// first weather + forecast fetch.
+/// first weather + forecast fetch -- unless no config file existed yet (a
+/// fresh install), in which case Preferences opens automatically instead of
+/// firing a fetch that's guaranteed to fail against `AppConfig::default()`'s
+/// unset API token (see `docs`/issue #38 for why: `WeatherProviderFactory`
+/// requires a token for every provider now, and the default config has
+/// none).
 pub fn boot() -> (AppState, Task<Message>) {
     let config_manager = ConfigManager::new().expect("Failed to create config manager");
+    let is_first_run = !config_manager.config_exists();
     let config = config_manager.load_config();
 
-    let (main_window, open_task) = window::open(window::Settings {
+    let (main_window, main_open_task) = window::open(window::Settings {
         size: Size::new(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT),
         min_size: Some(MAIN_WINDOW_MIN_SIZE),
         icon: crate::ui::icons::load_window_icon("icon/icon.png"),
         ..window::Settings::default()
     });
 
-    let fetch_tasks = Task::batch([fetch_weather_task(&config), fetch_forecast_task(&config)]);
+    let (prefs_window, prefs_state, second_task) = if is_first_run {
+        let mut prefs_state = preferences::State::from_config(&config);
+        prefs_state.is_first_run = true;
+        let (id, prefs_open_task) = window::open(preferences_window_settings());
+        (Some(id), Some(prefs_state), prefs_open_task.discard())
+    } else {
+        (
+            None,
+            None,
+            Task::batch([fetch_weather_task(&config), fetch_forecast_task(&config)]),
+        )
+    };
 
     let state = AppState {
         weather: WeatherStatus::Loading,
@@ -267,14 +302,15 @@ pub fn boot() -> (AppState, Task<Message>) {
         value_tracker: transition::ValueTracker::default(),
         selected_forecast_day: None,
         main_window,
-        prefs_window: None,
-        prefs_state: None,
+        prefs_window,
+        prefs_state,
         about_window: None,
+        is_first_run,
         config,
         config_manager,
     };
 
-    (state, Task::batch([open_task.discard(), fetch_tasks]))
+    (state, Task::batch([main_open_task.discard(), second_task]))
 }
 
 pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
@@ -363,12 +399,7 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                 return Task::none();
             }
             state.prefs_state = Some(preferences::State::from_config(&state.config));
-            let (id, open_task) = window::open(window::Settings {
-                size: Size::new(520.0, 560.0),
-                min_size: Some(PREFERENCES_WINDOW_MIN_SIZE),
-                icon: crate::ui::icons::load_window_icon("icon/icon.png"),
-                ..window::Settings::default()
-            });
+            let (id, open_task) = window::open(preferences_window_settings());
             state.prefs_window = Some(id);
             open_task.discard()
         }
@@ -411,6 +442,7 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
             if state.prefs_window == Some(id) {
                 state.prefs_window = None;
                 state.prefs_state = None;
+                state.is_first_run = false;
                 return window::close(id);
             }
             if state.about_window == Some(id) {
@@ -437,6 +469,10 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
             } else {
                 log::info!("Configuration saved successfully");
             }
+            // Whatever brought up first-run setup is now resolved -- a
+            // later manual reopen (toolbar gear icon) should show the
+            // ordinary "Preferences" copy, not the welcome banner again.
+            state.is_first_run = false;
             let close_task = state
                 .prefs_window
                 .take()
@@ -446,11 +482,15 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
         }
         Message::Preferences(preferences::Message::Cancel) => {
             state.prefs_state = None;
+            state.is_first_run = false;
             state
                 .prefs_window
                 .take()
                 .map(window::close)
                 .unwrap_or_else(Task::none)
+        }
+        Message::Preferences(preferences::Message::OpenUrl(url)) => {
+            Task::done(Message::OpenUrl(url))
         }
         Message::Preferences(sub_message) => {
             if let Some(prefs_state) = state.prefs_state.as_mut() {
@@ -504,7 +544,11 @@ pub fn theme(state: &AppState, _window: window::Id) -> Theme {
 
 pub fn title(state: &AppState, window_id: window::Id) -> String {
     if Some(window_id) == state.prefs_window {
-        "Preferences".to_string()
+        if state.is_first_run {
+            "Welcome to Weather Wizard".to_string()
+        } else {
+            "Preferences".to_string()
+        }
     } else if Some(window_id) == state.about_window {
         "About Weather Wizard".to_string()
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,26 @@ impl AppConfig {
             Err(e) => Err(format!("Failed to read API token: {e}")),
         }
     }
+
+    /// Removes the API token from the OS's secure credential store
+    /// entirely, rather than overwriting it with an empty string --
+    /// deleting the credential itself is what `examples/clear_credentials.rs`
+    /// needs, and matches what a user uninstalling the app or switching
+    /// machines would actually want. Not currently exposed anywhere in the
+    /// app's own UI (Preferences only ever sets a new token); a missing
+    /// entry is not an error, since that's already the desired end state.
+    // The binary crate's own `mod config` (src/main.rs) never calls this --
+    // only `examples/clear_credentials.rs` does, which links against the
+    // library crate's copy, a separate compilation -- hence the `allow`
+    // (same reasoning as `ConfigManager::for_path` above).
+    #[allow(dead_code)]
+    pub fn delete_api_token(&self) -> Result<(), String> {
+        match keyring_entry()?.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(format!("Failed to delete API token: {e}")),
+        }
+    }
 }
 
 /// The single `keyring::Entry` this app ever uses for the OpenWeatherMap API

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,6 +190,17 @@ impl ConfigManager {
         Ok(Self { config_path })
     }
 
+    /// Whether a config file already exists on disk -- the signal `app::boot`
+    /// uses to distinguish a fresh install (no file yet, so nothing has ever
+    /// been configured) from a returning user, since `load_config` itself
+    /// can't tell the difference (a missing or unparsable file both silently
+    /// fall back to `AppConfig::default()`). Must be checked *before*
+    /// calling `load_config`, which doesn't create the file itself --  only
+    /// `save_config` does.
+    pub fn config_exists(&self) -> bool {
+        self.config_path.exists()
+    }
+
     /// Points a `ConfigManager` at an arbitrary file, bypassing the real OS
     /// config directory -- so tests can exercise `load_config`/`save_config`
     /// (in particular the legacy-token migration, which needs real file

--- a/src/geolocation.rs
+++ b/src/geolocation.rs
@@ -1,0 +1,85 @@
+//! # IP-Based Location Detection
+//!
+//! Best-effort convenience for prefilling the "Home" location during
+//! first-run setup (see issue #38, and the broader geolocation tracking
+//! issue #5): resolves an approximate city/state/country from the caller's
+//! public IP address via [freeipapi.com](https://freeipapi.com/)'s free,
+//! keyless HTTPS endpoint.
+//!
+//! No cross-platform OS geolocation API (CoreLocation on macOS, the WinRT
+//! `Geolocator` on Windows, GeoClue on Linux) is used here -- bridging three
+//! separate platform APIs for the same one-time convenience prefill would be
+//! a lot of dependency weight, and none of them work headlessly in CI
+//! anyway. IP geolocation is ISP-routing-based, not GPS-accurate, so this is
+//! explicitly a starting point the user can (and often should) correct, not
+//! a precise location -- callers must treat a failure as "leave the
+//! existing fields alone," never as an error worth surfacing loudly.
+
+use crate::config::LocationConfig;
+use serde::Deserialize;
+
+const IP_GEOLOCATION_API: &str = "https://freeipapi.com/api/json/";
+
+/// The subset of freeipapi.com's response this app actually uses --
+/// `regionCode` is the two-letter code (e.g. `"IL"`), matching the format
+/// `LocationConfig.state`/the Google Weather provider's own
+/// `US_STATE_ABBREVIATIONS` table already assume.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct IpGeolocationResponse {
+    city_name: String,
+    region_code: String,
+    country_code: String,
+}
+
+/// Detects an approximate `LocationConfig` from the caller's public IP
+/// address. Returns a plain `String` error (network/parse failure) rather
+/// than a richer error type -- the only caller (`app.rs`) just logs it and
+/// leaves whatever location fields were already there untouched, since this
+/// is a convenience, not a fetch the UI needs to react to differently by
+/// failure mode.
+pub async fn detect_location() -> Result<LocationConfig, String> {
+    let response = reqwest::get(IP_GEOLOCATION_API)
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    let parsed = response
+        .json::<IpGeolocationResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))?;
+
+    Ok(LocationConfig {
+        city: parsed.city_name,
+        state: parsed.region_code,
+        country: parsed.country_code,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ip_geolocation_response_deserializes_and_maps() {
+        let json = r#"{
+            "ipVersion": 4,
+            "ipAddress": "98.227.181.31",
+            "latitude": 41.885,
+            "longitude": -87.7845,
+            "countryName": "United States",
+            "countryCode": "US",
+            "cityName": "Oak Park",
+            "regionName": "Illinois",
+            "regionCode": "IL"
+        }"#;
+        let parsed: IpGeolocationResponse = serde_json::from_str(json).unwrap();
+        let location = LocationConfig {
+            city: parsed.city_name,
+            state: parsed.region_code,
+            country: parsed.country_code,
+        };
+        assert_eq!(location.city, "Oak Park");
+        assert_eq!(location.state, "IL");
+        assert_eq!(location.country, "US");
+    }
+}

--- a/src/geolocation.rs
+++ b/src/geolocation.rs
@@ -1,58 +1,418 @@
-//! # IP-Based Location Detection
+//! # Location Detection
 //!
-//! Best-effort convenience for prefilling the "Home" location during
+//! Best-effort location detection for prefilling the "Home" location during
 //! first-run setup (see issue #38, and the broader geolocation tracking
-//! issue #5): resolves an approximate city/state/country from the caller's
-//! public IP address via [freeipapi.com](https://freeipapi.com/)'s free,
-//! keyless HTTPS endpoint.
+//! issue #5). Two-tier, in order:
 //!
-//! No cross-platform OS geolocation API (CoreLocation on macOS, the WinRT
-//! `Geolocator` on Windows, GeoClue on Linux) is used here -- bridging three
-//! separate platform APIs for the same one-time convenience prefill would be
-//! a lot of dependency weight, and none of them work headlessly in CI
-//! anyway. IP geolocation is ISP-routing-based, not GPS-accurate, so this is
-//! explicitly a starting point the user can (and often should) correct, not
-//! a precise location -- callers must treat a failure as "leave the
-//! existing fields alone," never as an error worth surfacing loudly.
+//! 1. **OS-native location** (`os_location`) -- CoreLocation on macOS, the
+//!    WinRT `Geolocator` on Windows, GeoClue2 on Linux -- reverse-geocoded
+//!    (`reverse_geocode`, via OpenStreetMap's Nominatim) into a city/state/
+//!    country. This is what real GPS/Wi-Fi/cell-tower-based positioning
+//!    looks like; when available and permitted, it's far more accurate than
+//!    IP geolocation.
+//! 2. **IP-based geolocation** (`ip_location`, via `ipwho.is`), used only
+//!    when native location is unavailable, denied, or fails. IP geolocation
+//!    resolves to wherever the ISP's routing infrastructure is registered,
+//!    not the physical location -- confirmed inaccurate by a real-world test
+//!    (three different free providers all missed by tens of miles) -- so
+//!    it's a last-resort fallback, not the primary path.
+//!
+//! Every failure mode -- no native API on this platform, permission denied,
+//! no result, a network error -- degrades to the next tier rather than
+//! surfacing as an error, since this whole feature is a convenience prefill
+//! the user can always override by typing. Only if *every* tier fails does
+//! `detect_location` return an `Err` at all.
 
 use crate::config::LocationConfig;
-use serde::Deserialize;
 
-const IP_GEOLOCATION_API: &str = "https://freeipapi.com/api/json/";
-
-/// The subset of freeipapi.com's response this app actually uses --
-/// `regionCode` is the two-letter code (e.g. `"IL"`), matching the format
-/// `LocationConfig.state`/the Google Weather provider's own
-/// `US_STATE_ABBREVIATIONS` table already assume.
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct IpGeolocationResponse {
-    city_name: String,
-    region_code: String,
-    country_code: String,
+/// Detects an approximate "Home" location: OS-native positioning
+/// (reverse-geocoded) if available, otherwise an IP-based lookup.
+pub async fn detect_location() -> Result<LocationConfig, String> {
+    if let Some((lat, lon)) = os_location::coordinates().await {
+        match reverse_geocode::reverse_geocode(lat, lon).await {
+            Ok(location) => return Ok(location),
+            Err(e) => log::warn!("Reverse geocoding failed, falling back to IP lookup: {e}"),
+        }
+    }
+    ip_location::detect().await
 }
 
-/// Detects an approximate `LocationConfig` from the caller's public IP
-/// address. Returns a plain `String` error (network/parse failure) rather
-/// than a richer error type -- the only caller (`app.rs`) just logs it and
-/// leaves whatever location fields were already there untouched, since this
-/// is a convenience, not a fetch the UI needs to react to differently by
-/// failure mode.
-pub async fn detect_location() -> Result<LocationConfig, String> {
-    let response = reqwest::get(IP_GEOLOCATION_API)
-        .await
-        .map_err(|e| format!("Request failed: {e}"))?;
+/// IP-based geolocation -- the fallback tier. `ipwho.is` (free, keyless,
+/// HTTPS) was chosen after comparing it against two other free providers on
+/// a real connection; all three were inaccurate to varying degrees (an
+/// inherent limitation of IP geolocation, not something a provider swap
+/// fixes outright), but this one was closest.
+mod ip_location {
+    use super::LocationConfig;
+    use serde::Deserialize;
 
-    let parsed = response
-        .json::<IpGeolocationResponse>()
-        .await
-        .map_err(|e| format!("Failed to parse response: {e}"))?;
+    const IP_GEOLOCATION_API: &str = "https://ipwho.is/";
 
-    Ok(LocationConfig {
-        city: parsed.city_name,
-        state: parsed.region_code,
-        country: parsed.country_code,
-    })
+    #[derive(Deserialize, Debug)]
+    pub(super) struct IpGeolocationResponse {
+        pub(super) success: bool,
+        pub(super) city: String,
+        pub(super) region_code: String,
+        pub(super) country_code: String,
+    }
+
+    pub async fn detect() -> Result<LocationConfig, String> {
+        let response = reqwest::get(IP_GEOLOCATION_API)
+            .await
+            .map_err(|e| format!("Request failed: {e}"))?;
+
+        let parsed = response
+            .json::<IpGeolocationResponse>()
+            .await
+            .map_err(|e| format!("Failed to parse response: {e}"))?;
+
+        if !parsed.success {
+            return Err("ipwho.is reported a lookup failure".to_string());
+        }
+
+        Ok(LocationConfig {
+            city: parsed.city,
+            state: parsed.region_code,
+            country: parsed.country_code,
+        })
+    }
+}
+
+/// Turns OS-native coordinates into a city/state/country, via OpenStreetMap's
+/// free, keyless Nominatim reverse-geocoding API -- shared by all three
+/// platforms in `os_location`, since CoreLocation/WinRT/GeoClue2 all return
+/// only latitude/longitude, never a place name.
+mod reverse_geocode {
+    use super::LocationConfig;
+    use serde::Deserialize;
+
+    const REVERSE_GEOCODE_API: &str = "https://nominatim.openstreetmap.org/reverse";
+    /// Nominatim's usage policy requires a descriptive User-Agent identifying
+    /// the calling application -- an unidentified/generic one risks being
+    /// rate-limited or blocked.
+    const USER_AGENT: &str = concat!(
+        "open-weather-wizard/",
+        env!("CARGO_PKG_VERSION"),
+        " (github.com/arunkumar-mourougappane/open-weather-wizard)"
+    );
+
+    /// Deliberately country-independent: `state` and `country_code` are
+    /// stored exactly as Nominatim returns them for *this* address, not
+    /// normalized against any single country's convention (e.g. no US
+    /// state-abbreviation lookup) -- this runs for any location on Earth.
+    #[derive(Deserialize, Debug, Default)]
+    pub(super) struct Address {
+        pub(super) city: Option<String>,
+        pub(super) town: Option<String>,
+        pub(super) village: Option<String>,
+        #[serde(default)]
+        pub(super) state: String,
+        #[serde(default)]
+        pub(super) country_code: String,
+    }
+
+    #[derive(Deserialize, Debug, Default)]
+    pub(super) struct ReverseGeocodeResponse {
+        #[serde(default)]
+        pub(super) address: Address,
+    }
+
+    pub async fn reverse_geocode(lat: f64, lon: f64) -> Result<LocationConfig, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(REVERSE_GEOCODE_API)
+            .query(&[
+                ("lat", lat.to_string()),
+                ("lon", lon.to_string()),
+                ("format", "jsonv2".to_string()),
+                ("addressdetails", "1".to_string()),
+            ])
+            .header(reqwest::header::USER_AGENT, USER_AGENT)
+            .send()
+            .await
+            .map_err(|e| format!("Request failed: {e}"))?;
+
+        let parsed = response
+            .json::<ReverseGeocodeResponse>()
+            .await
+            .map_err(|e| format!("Failed to parse response: {e}"))?;
+
+        // Nominatim varies which of these three keys it returns depending on
+        // settlement size -- try each in turn rather than picking just one.
+        let city = parsed
+            .address
+            .city
+            .or(parsed.address.town)
+            .or(parsed.address.village)
+            .ok_or_else(|| "No city/town/village in reverse-geocode response".to_string())?;
+
+        Ok(LocationConfig {
+            city,
+            state: parsed.address.state,
+            // Nominatim returns a lowercase ISO code (e.g. "us"); this app's
+            // convention elsewhere (defaults, Google Weather's country param)
+            // is uppercase.
+            country: parsed.address.country_code.to_uppercase(),
+        })
+    }
+}
+
+/// OS-native positioning coordinates, dispatched per-platform. `None` on
+/// any failure/denial/unsupported-platform -- this layer never returns an
+/// `Err`, since a real error is only meaningful once the IP-based fallback
+/// (the last tier) also fails.
+mod os_location {
+    pub async fn coordinates() -> Option<(f64, f64)> {
+        #[cfg(target_os = "macos")]
+        return macos::coordinates().await;
+        #[cfg(target_os = "windows")]
+        return windows::coordinates().await;
+        #[cfg(target_os = "linux")]
+        return linux::coordinates().await;
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        None
+    }
+
+    /// CoreLocation, via the low-level `objc2-core-location` bindings (no
+    /// ergonomic wrapper crate exists). Requires the process to be a signed
+    /// `.app` bundle with an `NSLocationWhenInUseUsageDescription` Info.plist
+    /// key to ever show the permission prompt (see `packaging/macos/
+    /// Info.plist` and `Cargo.toml`'s `package.metadata.packager.macos`) --
+    /// a plain `cargo run` dev binary gets an immediate `denied`/
+    /// `notDetermined`-with-no-prompt and falls through to IP, which is
+    /// expected and was confirmed by actually running this code during
+    /// development.
+    #[cfg(target_os = "macos")]
+    mod macos {
+        use std::cell::RefCell;
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        use objc2::rc::Retained;
+        use objc2::runtime::ProtocolObject;
+        use objc2::{AnyThread, DefinedClass, define_class, msg_send};
+        use objc2_core_foundation::CFRunLoop;
+        use objc2_core_location::{
+            CLAuthorizationStatus, CLLocation, CLLocationManager, CLLocationManagerDelegate,
+        };
+        use objc2_foundation::{NSArray, NSError, NSObject, NSObjectProtocol};
+
+        type CoordinatesSender = mpsc::Sender<Option<(f64, f64)>>;
+
+        struct Ivars {
+            tx: RefCell<Option<CoordinatesSender>>,
+        }
+
+        define_class!(
+            #[unsafe(super(NSObject))]
+            #[ivars = Ivars]
+            struct LocationDelegate;
+
+            impl LocationDelegate {}
+
+            unsafe impl NSObjectProtocol for LocationDelegate {}
+
+            unsafe impl CLLocationManagerDelegate for LocationDelegate {
+                #[unsafe(method(locationManager:didUpdateLocations:))]
+                fn location_manager_did_update_locations(
+                    &self,
+                    _manager: &CLLocationManager,
+                    locations: &NSArray<CLLocation>,
+                ) {
+                    if let Some(tx) = self.ivars().tx.borrow_mut().take() {
+                        let coords = locations.lastObject().map(|loc| {
+                            let c = unsafe { loc.coordinate() };
+                            (c.latitude, c.longitude)
+                        });
+                        let _ = tx.send(coords);
+                    }
+                }
+
+                #[unsafe(method(locationManager:didFailWithError:))]
+                fn location_manager_did_fail_with_error(
+                    &self,
+                    _manager: &CLLocationManager,
+                    _error: &NSError,
+                ) {
+                    if let Some(tx) = self.ivars().tx.borrow_mut().take() {
+                        let _ = tx.send(None);
+                    }
+                }
+            }
+        );
+
+        impl LocationDelegate {
+            fn new(tx: CoordinatesSender) -> Retained<Self> {
+                let this = Self::alloc().set_ivars(Ivars {
+                    tx: RefCell::new(Some(tx)),
+                });
+                unsafe { msg_send![super(this), init] }
+            }
+        }
+
+        pub async fn coordinates() -> Option<(f64, f64)> {
+            // CLLocationManager's delegate callbacks require an active run
+            // loop on the thread that owns it, which tokio's async
+            // executor doesn't provide -- run the whole interaction on a
+            // dedicated blocking thread that pumps its own short-lived
+            // CFRunLoop instead.
+            tokio::task::spawn_blocking(coordinates_blocking)
+                .await
+                .unwrap_or(None)
+        }
+
+        fn coordinates_blocking() -> Option<(f64, f64)> {
+            let manager = unsafe { CLLocationManager::new() };
+            let status = unsafe { manager.authorizationStatus() };
+
+            if status == CLAuthorizationStatus::Denied
+                || status == CLAuthorizationStatus::Restricted
+            {
+                return None;
+            }
+
+            let (tx, rx) = mpsc::channel();
+            let delegate = LocationDelegate::new(tx);
+            unsafe { manager.setDelegate(Some(ProtocolObject::from_ref(&*delegate))) };
+
+            if status == CLAuthorizationStatus::NotDetermined {
+                unsafe { manager.requestWhenInUseAuthorization() };
+            }
+
+            unsafe { manager.requestLocation() };
+
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Ok(result) = rx.try_recv() {
+                    return result;
+                }
+                if Instant::now() >= deadline {
+                    return None;
+                }
+                CFRunLoop::run_in_mode(
+                    unsafe { objc2_core_foundation::kCFRunLoopDefaultMode },
+                    0.1,
+                    false,
+                );
+            }
+        }
+    }
+
+    /// The WinRT `Geolocator` API, via the `windows` crate. `RequestAccessAsync`
+    /// shows the system permission prompt; `GetGeopositionAsync` then performs
+    /// a one-shot fetch. Any denial or `windows::core::Error` maps to `None`.
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use windows::Devices::Geolocation::{GeolocationAccessStatus, Geolocator};
+
+        pub async fn coordinates() -> Option<(f64, f64)> {
+            let access = Geolocator::RequestAccessAsync().ok()?.await.ok()?;
+            if access != GeolocationAccessStatus::Allowed {
+                return None;
+            }
+
+            let geolocator = Geolocator::new().ok()?;
+            let position = geolocator.GetGeopositionAsync().ok()?.await.ok()?;
+            let coordinate = position.Coordinate().ok()?;
+            let point = coordinate.Point().ok()?;
+            let basic = point.Position().ok()?;
+
+            Some((basic.Latitude, basic.Longitude))
+        }
+    }
+
+    /// GeoClue2 over D-Bus (`org.freedesktop.GeoClue2`), via `zbus`. Requires
+    /// a running `geoclue2` daemon (absent on plenty of minimal/non-GNOME
+    /// distros) and registers with the `DesktopId` matching this app's
+    /// `open-weather-wizard.desktop` file, per GeoClue2's per-app permission
+    /// model. No session bus, no daemon, or denied permission all map to
+    /// `None`.
+    #[cfg(target_os = "linux")]
+    mod linux {
+        use futures_util::StreamExt;
+        use std::time::Duration;
+        use zbus::Connection;
+        use zbus::proxy;
+        use zbus::zvariant::OwnedObjectPath;
+
+        #[proxy(
+            interface = "org.freedesktop.GeoClue2.Manager",
+            default_service = "org.freedesktop.GeoClue2",
+            default_path = "/org/freedesktop/GeoClue2/Manager"
+        )]
+        trait Manager {
+            fn get_client(&self) -> zbus::Result<OwnedObjectPath>;
+        }
+
+        #[proxy(
+            interface = "org.freedesktop.GeoClue2.Client",
+            default_service = "org.freedesktop.GeoClue2"
+        )]
+        trait Client {
+            fn start(&self) -> zbus::Result<()>;
+            fn stop(&self) -> zbus::Result<()>;
+
+            #[zbus(property)]
+            fn set_desktop_id(&self, id: &str) -> zbus::Result<()>;
+
+            #[zbus(signal)]
+            fn location_updated(
+                &self,
+                old: OwnedObjectPath,
+                new: OwnedObjectPath,
+            ) -> zbus::Result<()>;
+        }
+
+        #[proxy(
+            interface = "org.freedesktop.GeoClue2.Location",
+            default_service = "org.freedesktop.GeoClue2"
+        )]
+        trait Location {
+            #[zbus(property)]
+            fn latitude(&self) -> zbus::Result<f64>;
+            #[zbus(property)]
+            fn longitude(&self) -> zbus::Result<f64>;
+        }
+
+        pub async fn coordinates() -> Option<(f64, f64)> {
+            let connection = Connection::session().await.ok()?;
+
+            let manager = ManagerProxy::new(&connection).await.ok()?;
+            let client_path = manager.get_client().await.ok()?;
+
+            let client = ClientProxy::builder(&connection)
+                .path(client_path)
+                .ok()?
+                .build()
+                .await
+                .ok()?;
+
+            client.set_desktop_id("open-weather-wizard").await.ok()?;
+
+            let mut updates = client.receive_location_updated().await.ok()?;
+            client.start().await.ok()?;
+
+            let signal = tokio::time::timeout(Duration::from_secs(5), updates.next())
+                .await
+                .ok()??;
+            let args = signal.args().ok()?;
+            let location_path = args.new.clone();
+
+            let location = LocationProxy::builder(&connection)
+                .path(location_path)
+                .ok()?
+                .build()
+                .await
+                .ok()?;
+
+            let lat = location.latitude().await.ok()?;
+            let lon = location.longitude().await.ok()?;
+
+            let _ = client.stop().await;
+
+            Some((lat, lon))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -62,24 +422,48 @@ mod tests {
     #[test]
     fn test_ip_geolocation_response_deserializes_and_maps() {
         let json = r#"{
-            "ipVersion": 4,
-            "ipAddress": "98.227.181.31",
-            "latitude": 41.885,
-            "longitude": -87.7845,
-            "countryName": "United States",
-            "countryCode": "US",
-            "cityName": "Oak Park",
-            "regionName": "Illinois",
-            "regionCode": "IL"
+            "ip": "98.227.181.31",
+            "success": true,
+            "city": "Peoria Heights",
+            "region": "Illinois",
+            "region_code": "IL",
+            "country_code": "US"
         }"#;
-        let parsed: IpGeolocationResponse = serde_json::from_str(json).unwrap();
-        let location = LocationConfig {
-            city: parsed.city_name,
-            state: parsed.region_code,
-            country: parsed.country_code,
-        };
-        assert_eq!(location.city, "Oak Park");
-        assert_eq!(location.state, "IL");
-        assert_eq!(location.country, "US");
+        let parsed: ip_location::IpGeolocationResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.success);
+        assert_eq!(parsed.city, "Peoria Heights");
+        assert_eq!(parsed.region_code, "IL");
+        assert_eq!(parsed.country_code, "US");
+    }
+
+    #[test]
+    fn test_reverse_geocode_response_deserializes_and_maps() {
+        let json = r#"{
+            "address": {
+                "city": "Dunlap",
+                "state": "Illinois",
+                "country_code": "us"
+            }
+        }"#;
+        let parsed: reverse_geocode::ReverseGeocodeResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.address.city.as_deref(), Some("Dunlap"));
+        assert_eq!(parsed.address.state, "Illinois");
+        assert_eq!(parsed.address.country_code, "us");
+    }
+
+    #[test]
+    fn test_reverse_geocode_response_falls_back_to_town() {
+        // Smaller settlements come back under `town` or `village` instead
+        // of `city`.
+        let json = r#"{
+            "address": {
+                "town": "Dunlap",
+                "state": "Illinois",
+                "country_code": "us"
+            }
+        }"#;
+        let parsed: reverse_geocode::ReverseGeocodeResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.address.city.is_none());
+        assert_eq!(parsed.address.town.as_deref(), Some("Dunlap"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,33 @@ mod tests {
         let _ = std::fs::remove_file(&config_path);
     }
 
+    /// Verifies `ConfigManager::config_exists` -- the signal `app::boot`
+    /// uses to detect a fresh install (see issue #38) -- correctly reports
+    /// `false` before any config has ever been saved and `true` immediately
+    /// after `save_config` first writes the file.
+    #[test]
+    fn test_config_manager_detects_first_run() {
+        let config_path = std::env::temp_dir().join(format!(
+            "open-weather-wizard-first-run-test-{:?}.json",
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_file(&config_path);
+
+        let manager = ConfigManager::for_path(config_path.clone());
+        assert!(
+            !manager.config_exists(),
+            "no config file has been saved yet"
+        );
+
+        manager.save_config(&AppConfig::default()).unwrap();
+        assert!(
+            manager.config_exists(),
+            "config_exists should be true immediately after save_config"
+        );
+
+        let _ = std::fs::remove_file(&config_path);
+    }
+
     /// Tests the `WeatherProviderFactory`'s ability to create providers.
     ///
     /// This test covers both successful creation and error handling for missing API keys.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,15 @@
 //!
 //! - **`app`**: The iced application root -- state, messages, `update()`/`view()`.
 //! - **`config`**: Handles loading, saving, and managing application configuration.
+//! - **`geolocation`**: Best-effort IP-based location detection, used to prefill
+//!   the "Home" location during first-run setup.
 //! - **`ui`**: Per-screen views for the [iced](https://github.com/iced-rs/iced) user interface.
 //! - **`weather_api`**: Provides an abstraction layer for fetching data from various
 //!   weather services.
 
 pub mod app;
 pub mod config;
+pub mod geolocation;
 pub mod ui;
 pub mod weather_api;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use log::{self, LevelFilter};
 
 mod app;
 mod config;
+mod geolocation;
 mod ui;
 mod weather_api;
 

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -38,6 +38,16 @@ pub struct State {
     /// window's title (`app::title`); every field and validation rule
     /// behaves identically either way.
     pub is_first_run: bool,
+    /// Whether an IP-based location lookup (`Message::DetectLocationRequested`,
+    /// intercepted by `app::update`) is currently in flight -- disables the
+    /// "Detect my location" button and swaps its label so a slow/failed
+    /// lookup doesn't look like a dead button.
+    pub is_detecting_location: bool,
+    /// Set if the last detection attempt failed, cleared on the next
+    /// attempt or a successful one. Never blocks Save -- detection is a
+    /// convenience prefill, not a required step; the fields can always be
+    /// typed in by hand instead.
+    pub location_detection_error: Option<String>,
 }
 
 impl State {
@@ -51,6 +61,8 @@ impl State {
             dark_mode: config.dark_mode,
             use_fahrenheit: config.use_fahrenheit,
             is_first_run: false,
+            is_detecting_location: false,
+            location_detection_error: None,
         }
     }
 
@@ -105,13 +117,20 @@ pub enum Message {
     /// browser is an app-level concern, not something this module does
     /// itself.
     OpenUrl(String),
+    /// The "Detect my location" button -- intercepted by the parent, which
+    /// kicks off the async IP lookup (`crate::geolocation::detect_location`)
+    /// and reports back via the app-level `Message::LocationDetected`, since
+    /// firing an async `Task` isn't something this module's synchronous
+    /// `update` can do itself.
+    DetectLocationRequested,
     Save,
     Cancel,
 }
 
-/// Mutates field-edit messages; `Save`/`Cancel`/`OpenUrl` are intercepted by
-/// the parent `AppState::update` (see `src/app.rs`) since they need access to
-/// `AppConfig`/the OS's URL opener respectively.
+/// Mutates field-edit messages; `Save`/`Cancel`/`OpenUrl`/
+/// `DetectLocationRequested` are intercepted by the parent `AppState::update`
+/// (see `src/app.rs`) since they need access to `AppConfig`/the OS's URL
+/// opener/an async `Task` respectively.
 pub fn update(state: &mut State, message: Message) {
     match message {
         Message::ProviderSelected(provider) => state.provider = provider,
@@ -121,7 +140,10 @@ pub fn update(state: &mut State, message: Message) {
         Message::CountryChanged(value) => state.country_input = value,
         Message::DarkModeToggled(value) => state.dark_mode = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
-        Message::OpenUrl(_) | Message::Save | Message::Cancel => {
+        Message::OpenUrl(_)
+        | Message::DetectLocationRequested
+        | Message::Save
+        | Message::Cancel => {
             // Handled by the parent; nothing to do locally.
         }
     }
@@ -171,31 +193,39 @@ pub fn view(state: &State) -> Element<'_, Message> {
         .into(),
     );
 
-    let location_section = section(
-        "\u{25ce} Default Location",
-        column![
-            labeled_row(
-                "City:",
-                text_input("Enter city name", &state.city_input)
-                    .on_input(Message::CityChanged)
-                    .into()
-            ),
-            labeled_row(
-                "State/Province:",
-                text_input("Enter state or province", &state.state_input)
-                    .on_input(Message::StateChanged)
-                    .into()
-            ),
-            labeled_row(
-                "Country:",
-                text_input("Enter country code (e.g., US, CA)", &state.country_input)
-                    .on_input(Message::CountryChanged)
-                    .into()
-            ),
-        ]
-        .spacing(12)
-        .into(),
-    );
+    let mut location_column = column![
+        labeled_row(
+            "City:",
+            text_input("Enter city name", &state.city_input)
+                .on_input(Message::CityChanged)
+                .into()
+        ),
+        labeled_row(
+            "State/Province:",
+            text_input("Enter state or province", &state.state_input)
+                .on_input(Message::StateChanged)
+                .into()
+        ),
+        labeled_row(
+            "Country:",
+            text_input("Enter country code (e.g., US, CA)", &state.country_input)
+                .on_input(Message::CountryChanged)
+                .into()
+        ),
+        detect_location_row(state.is_detecting_location),
+    ]
+    .spacing(12);
+
+    if let Some(error) = &state.location_detection_error {
+        location_column = location_column.push(location_hint_row(
+            text(error.clone()).size(12).style(style::danger).into(),
+        ));
+    }
+
+    // "Home" rather than "Default Location": this is a single saved place
+    // (where the app opens showing conditions for), not a location picker --
+    // multi-location support is tracked separately (issue #5).
+    let location_section = section("\u{2302} Home", location_column.into());
 
     let appearance_section = section(
         "\u{263e} Appearance",
@@ -241,7 +271,8 @@ pub fn view(state: &State) -> Element<'_, Message> {
                     .style(style::accent),
                 text(
                     "Choose a weather provider, add its API key, and set your \
-                     default location to get started."
+                     Home location (typed in, or detected from your IP address) \
+                     to get started."
                 )
                 .size(12)
                 .style(style::muted),
@@ -303,5 +334,32 @@ fn api_key_hint_row(label: &'static str, url: &'static str) -> Element<'static, 
             .style(style::link_button)
             .padding(0),
     ]
+    .into()
+}
+
+/// Indents an arbitrary element under the Home section's fields, aligning it
+/// under the input column rather than the label column (matching
+/// `labeled_row`'s 160px label width) -- used for the location-detection
+/// error line, which isn't itself a button/link like the other hint rows.
+fn location_hint_row(content: Element<'_, Message>) -> Element<'_, Message> {
+    row![space::horizontal().width(160), content].into()
+}
+
+/// The "Detect my location" button, indented to align under the Home
+/// section's input fields. A separate function (rather than inline in
+/// `view`) purely to give the surrounding `column!` macro's `Into<Element>`
+/// call an unambiguous type to infer against.
+fn detect_location_row(is_detecting: bool) -> Element<'static, Message> {
+    row![
+        space::horizontal().width(160),
+        button(text(if is_detecting {
+            "Detecting..."
+        } else {
+            "Detect my location"
+        }))
+        .on_press_maybe((!is_detecting).then_some(Message::DetectLocationRequested))
+        .style(style::secondary_button),
+    ]
+    .align_y(Alignment::Center)
     .into()
 }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -32,6 +32,12 @@ pub struct State {
     pub country_input: String,
     pub dark_mode: bool,
     pub use_fahrenheit: bool,
+    /// Set by `app::boot` when this window was opened automatically because
+    /// no config file existed yet (see `ConfigManager::config_exists`).
+    /// Purely cosmetic -- swaps in a welcome banner (`view`) and the
+    /// window's title (`app::title`); every field and validation rule
+    /// behaves identically either way.
+    pub is_first_run: bool,
 }
 
 impl State {
@@ -44,6 +50,7 @@ impl State {
             country_input: config.location.country.clone(),
             dark_mode: config.dark_mode,
             use_fahrenheit: config.use_fahrenheit,
+            is_first_run: false,
         }
     }
 
@@ -93,12 +100,18 @@ pub enum Message {
     CountryChanged(String),
     DarkModeToggled(bool),
     UnitsToggled(bool),
+    /// The "Get an API key" link -- intercepted by the parent (see
+    /// `src/app.rs`) and turned into `Message::OpenUrl`, since opening a
+    /// browser is an app-level concern, not something this module does
+    /// itself.
+    OpenUrl(String),
     Save,
     Cancel,
 }
 
-/// Mutates field-edit messages; `Save`/`Cancel` are intercepted by the parent
-/// `AppState::update` (see `src/app.rs`) since they need access to `AppConfig`.
+/// Mutates field-edit messages; `Save`/`Cancel`/`OpenUrl` are intercepted by
+/// the parent `AppState::update` (see `src/app.rs`) since they need access to
+/// `AppConfig`/the OS's URL opener respectively.
 pub fn update(state: &mut State, message: Message) {
     match message {
         Message::ProviderSelected(provider) => state.provider = provider,
@@ -108,13 +121,31 @@ pub fn update(state: &mut State, message: Message) {
         Message::CountryChanged(value) => state.country_input = value,
         Message::DarkModeToggled(value) => state.dark_mode = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
-        Message::Save | Message::Cancel => {
+        Message::OpenUrl(_) | Message::Save | Message::Cancel => {
             // Handled by the parent; nothing to do locally.
         }
     }
 }
 
+/// Where to get an API key for each provider, and a matching link label --
+/// shown under the API Token field regardless of first-run status, since
+/// switching providers later needs the same pointer.
+fn api_key_hint(provider: &WeatherApiProvider) -> (&'static str, &'static str) {
+    match provider {
+        WeatherApiProvider::OpenWeather => (
+            "Get an OpenWeatherMap API key",
+            "https://home.openweathermap.org/users/sign_up",
+        ),
+        WeatherApiProvider::GoogleWeather => (
+            "Get a Google Weather API key",
+            "https://developers.google.com/maps/documentation/weather/overview",
+        ),
+    }
+}
+
 pub fn view(state: &State) -> Element<'_, Message> {
+    let (hint_label, hint_url) = api_key_hint(&state.provider);
+
     let provider_section = section(
         "\u{2699} Weather Provider",
         column![
@@ -134,6 +165,7 @@ pub fn view(state: &State) -> Element<'_, Message> {
                     .on_input(Message::TokenChanged)
                     .into()
             ),
+            api_key_hint_row(hint_label, hint_url),
         ]
         .spacing(12)
         .into(),
@@ -193,12 +225,35 @@ pub fn view(state: &State) -> Element<'_, Message> {
     .spacing(8)
     .align_y(Alignment::Center);
 
-    // The window's own title bar already reads "Preferences" (see
-    // `app::title`), so an in-content heading would just repeat it.
-    let mut layout = column![provider_section, location_section, appearance_section,]
-        .spacing(16)
-        .padding(20)
-        .width(Length::Fill);
+    // Normally the window's own title bar already reads "Preferences" (see
+    // `app::title`), so an in-content heading would just repeat it -- but on
+    // first run the title bar instead reads "Welcome to Weather Wizard",
+    // and this banner is the one place that explains *why* the window
+    // opened on its own and what the three sections below are for.
+    let mut layout = column![].spacing(16).padding(20).width(Length::Fill);
+
+    if state.is_first_run {
+        layout = layout.push(
+            column![
+                text("Welcome to Weather Wizard!")
+                    .size(16)
+                    .font(BOLD)
+                    .style(style::accent),
+                text(
+                    "Choose a weather provider, add its API key, and set your \
+                     default location to get started."
+                )
+                .size(12)
+                .style(style::muted),
+            ]
+            .spacing(4),
+        );
+    }
+
+    layout = layout
+        .push(provider_section)
+        .push(location_section)
+        .push(appearance_section);
 
     if !errors.is_empty() {
         let mut error_list = column![].spacing(2);
@@ -235,4 +290,18 @@ fn labeled_row<'a>(label: &'a str, field: Element<'a, Message>) -> Element<'a, M
         .spacing(12)
         .align_y(Alignment::Center)
         .into()
+}
+
+/// The "Get an API key" link under the API Token field, indented to align
+/// under the input rather than the label (matching `labeled_row`'s 160px
+/// label column).
+fn api_key_hint_row(label: &'static str, url: &'static str) -> Element<'static, Message> {
+    row![
+        space::horizontal().width(160),
+        button(text(label).size(12))
+            .on_press(Message::OpenUrl(url.to_string()))
+            .style(style::link_button)
+            .padding(0),
+    ]
+    .into()
 }


### PR DESCRIPTION
## Summary
- Closes #38. A fresh install had no config file and no API token, and both providers now require one, so the very first fetch was guaranteed to fail with a bare error message and no indication that Preferences (the toolbar gear icon) was where to fix it.
- `ConfigManager::config_exists()` detects whether a config file existed before load — the signal `app::boot` uses to distinguish a fresh install from a returning user.
- On first run, `boot()` auto-opens Preferences instead of firing a fetch known in advance to fail; the window title reads "Welcome to Weather Wizard" and the form shows a welcome banner.
- Preferences gains a "Get an API key" link per provider (OpenWeatherMap signup / Google Cloud Weather API docs), shown regardless of first-run status since switching providers later needs the same pointer.
- `is_first_run` clears on Save, Cancel, or closing the window, so a later manual reopen via the toolbar never shows first-run copy again.
- A first slice of #5 (the broader geolocation tracking issue): the location section in Preferences is renamed "Home" and gains a "Detect my location" button.
- **Location detection is now two-tier**, after IP-only detection was confirmed too inaccurate (three free providers all missed a real connection's actual city by tens of miles — inherent to IP geolocation, not fixable by a provider swap alone):
  1. OS-native positioning first — CoreLocation (macOS, via the low-level `objc2-core-location` bindings), the WinRT `Geolocator` (Windows, via the `windows` crate), GeoClue2 (Linux, over D-Bus via `zbus`) — each behind a target-specific Cargo dependency.
  2. Coordinates get reverse-geocoded into city/state/country via OpenStreetMap's free Nominatim API (deliberately country-independent — no US-specific normalization).
  3. Falls back to the existing IP-based lookup (swapped to `ipwho.is`, the closest of three providers tested) only if native location is unavailable, denied, or fails.
- Adds `packaging/macos/Info.plist` + `package.metadata.packager.macos` in `Cargo.toml`, since the *packaged* macOS release needs the `NSLocationWhenInUseUsageDescription` key to ever show the location permission prompt — a bare dev binary never will regardless.
- Bonus: `examples/clear_credentials.rs` + `AppConfig::delete_api_token()` — a manual utility to delete the stored API token from the real OS keychain, gated behind a typed "yes" confirmation since it mutates real state.

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all` (32 tests, incl. fixture tests for the new IP/reverse-geocode response parsing)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] macOS location path: actually ran — `authorizationStatus` reads `NotDetermined` (expected for an unbundled `cargo run` binary), correctly falls through to the IP lookup
- [x] Linux GeoClue2 path: compiled and ran the `zbus` proxies on this (macOS) machine — no D-Bus session bus here, so it correctly returns `None` and falls through, the same failure mode as a Linux box without `geoclue2` installed
- [x] Full end-to-end chain, live: resolved to `Peoria Heights / IL / US`
- [ ] **Windows location path is unverified in this environment** — type-checked against the real `windows` 0.62 crate source, but I have no Windows machine to confirm the actual runtime/permission-prompt behavior. This repo's own CI builds on `windows-latest`, which will at least confirm it compiles; a real Windows user testing the "Detect my location" button is the only way to confirm the runtime behavior.
- [ ] Manual: confirm a fresh install (no `config.json`) opens Preferences automatically with the welcome banner
- [ ] Manual: click "Detect my location" in Preferences on each OS and confirm the permission prompt/fallback behavior