### PR TITLE
refactor(weather-api): backend cleanup pass

### DIFF
--- a/docs/GOOGLE_WEATHER_API.md
+++ b/docs/GOOGLE_WEATHER_API.md
@@ -13,10 +13,10 @@ Official docs: https://developers.google.com/maps/documentation/weather
 - Requires a Google Cloud project with billing enabled and the Weather API
   enabled on it, same as any other Maps Platform API.
 - Auth is a plain API key passed as the `key` query parameter — no OAuth,
-  no request signing. This matches the existing `WeatherProvider` shape
-  (`requires_api_key() -> bool`), so a real implementation would fit the same
-  `keyring`-backed token storage `src/config.rs` already uses for
-  OpenWeatherMap.
+  no request signing. This matches how `WeatherProviderFactory::create_provider`
+  already requires a token for every `WeatherApiProvider` variant, so a real
+  implementation fits the same `keyring`-backed token storage `src/config.rs`
+  already uses for OpenWeatherMap.
 - A no-cost "Maps Demo Key" exists for trying the API without attaching
   billing, but it's rate-limited/watermarked and not meant for production use.
 - Every real request needs a lat/lon pair (`location.latitude` /

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -94,7 +94,8 @@ impl State {
         if self.country_input.trim().is_empty() {
             errors.push("Country is required.".to_string());
         }
-        // Both providers require a token (see WeatherProvider::requires_api_key).
+        // Both providers require a token -- WeatherProviderFactory::create_provider
+        // errors out without one for either WeatherApiProvider variant.
         if self.token_input.trim().is_empty() {
             errors.push(format!("API Token is required for {}.", self.provider));
         }

--- a/src/weather_api/google_weather_api.rs
+++ b/src/weather_api/google_weather_api.rs
@@ -126,8 +126,10 @@ const US_STATE_ABBREVIATIONS: &[(&str, &str)] = &[
 /// `name`-only search can't tell "Peoria, IL" from "Peoria, AZ" apart, and
 /// picking the wrong one silently returns a real, plausible-looking, but
 /// entirely wrong forecast.
-async fn geocode(location: &LocationConfig) -> Result<(f64, f64), ApiError> {
-    let client = reqwest::Client::new();
+async fn geocode(
+    client: &reqwest::Client,
+    location: &LocationConfig,
+) -> Result<(f64, f64), ApiError> {
     let mut query = vec![
         ("name", location.city.clone()),
         ("count", "10".to_string()),
@@ -373,11 +375,11 @@ fn resolve_epoch_and_offset(rfc3339: &str, iana_zone_id: &str) -> (i64, i64) {
 }
 
 async fn fetch_current_conditions(
+    client: &reqwest::Client,
     api_key: &str,
     lat: f64,
     lon: f64,
 ) -> Result<CurrentConditionsResponse, ApiError> {
-    let client = reqwest::Client::new();
     let response = client
         .get(format!("{WEATHER_API_BASE}/currentConditions:lookup"))
         .query(&[
@@ -408,12 +410,12 @@ async fn fetch_current_conditions(
 }
 
 async fn fetch_forecast_days(
+    client: &reqwest::Client,
     api_key: &str,
     lat: f64,
     lon: f64,
     days: u8,
 ) -> Result<ForecastDaysResponse, ApiError> {
-    let client = reqwest::Client::new();
     let response = client
         .get(format!("{WEATHER_API_BASE}/forecast/days:lookup"))
         .query(&[
@@ -469,25 +471,34 @@ fn map_forecast_day(item: &ForecastDayItem) -> ForecastDay {
 /// Platform's Weather API.
 pub struct GoogleWeatherProvider {
     api_key: String,
+    /// Reused across every request this provider makes (geocoding, current
+    /// conditions, forecast) rather than building a fresh `reqwest::Client`
+    /// per call -- a `Client` holds a connection pool internally, so
+    /// constructing a new one per request throws away keep-alive/TLS-session
+    /// reuse for no benefit.
+    client: reqwest::Client,
 }
 
 impl GoogleWeatherProvider {
     /// Creates a new `GoogleWeatherProvider` with the given Google Cloud API
     /// key (must have the Weather API enabled on its project).
     pub fn new(api_key: String) -> Self {
-        Self { api_key }
+        Self {
+            api_key,
+            client: reqwest::Client::new(),
+        }
     }
 }
 
 #[async_trait]
 impl WeatherProvider for GoogleWeatherProvider {
     async fn get_weather(&self, location: &LocationConfig) -> Result<ApiResponse, ApiError> {
-        let (lat, lon) = geocode(location).await?;
+        let (lat, lon) = geocode(&self.client, location).await?;
 
-        let current = fetch_current_conditions(&self.api_key, lat, lon).await?;
+        let current = fetch_current_conditions(&self.client, &self.api_key, lat, lon).await?;
         // Sunrise/sunset and today's min/max only come from the daily
         // forecast, not currentConditions -- see the module doc.
-        let forecast = fetch_forecast_days(&self.api_key, lat, lon, 1).await?;
+        let forecast = fetch_forecast_days(&self.client, &self.api_key, lat, lon, 1).await?;
         let today = forecast
             .forecast_days
             .first()
@@ -524,8 +535,9 @@ impl WeatherProvider for GoogleWeatherProvider {
     }
 
     async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError> {
-        let (lat, lon) = geocode(location).await?;
-        let forecast = fetch_forecast_days(&self.api_key, lat, lon, FORECAST_DAYS).await?;
+        let (lat, lon) = geocode(&self.client, location).await?;
+        let forecast =
+            fetch_forecast_days(&self.client, &self.api_key, lat, lon, FORECAST_DAYS).await?;
 
         Ok(ForecastResponse {
             location_name: location.city.clone(),
@@ -535,14 +547,6 @@ impl WeatherProvider for GoogleWeatherProvider {
                 .map(map_forecast_day)
                 .collect(),
         })
-    }
-
-    fn name(&self) -> &'static str {
-        "Google Weather"
-    }
-
-    fn requires_api_key(&self) -> bool {
-        true
     }
 }
 

--- a/src/weather_api/openweather_api.rs
+++ b/src/weather_api/openweather_api.rs
@@ -172,8 +172,15 @@ async fn get_coords(
         .await
         .map_err(GeocodeError::RequestFailed)?;
     log::debug!("Geocoding response: {:?}", locations);
-    // The API returns an empty array `[]` if the location isn't found.
-    // We take the first element if it exists, otherwise return a `LocationNotFound` error.
+    select_location(locations)
+}
+
+/// The API returns an empty array `[]` if the location isn't found, and an
+/// array of matches (most relevant first, though `get_coords` already
+/// requests `limit=1`) otherwise -- take the first element if present, or
+/// `LocationNotFound` for an empty response. Split out from `get_coords` so
+/// this selection logic is testable without a live network call.
+fn select_location(locations: Vec<Location>) -> Result<Location, GeocodeError> {
     locations
         .into_iter()
         .next()
@@ -227,8 +234,8 @@ pub async fn get_weather(location: &Location, api_key: &str) -> Result<ApiRespon
     // Check if the request was successful (e.g., status 200 OK)
     if response.status().is_success() {
         // Try to parse the JSON response into our ApiResponse struct
-        response.json::<ApiResponse>().await.map_err(|_| {
-            log::error!("Failed to parse API response");
+        response.json::<ApiResponse>().await.map_err(|e| {
+            log::error!("Failed to parse API response: {e}");
             ApiError::InvalidResponse
         })
     } else {
@@ -261,8 +268,8 @@ pub async fn get_forecast(
         let raw = response
             .json::<crate::weather_api::forecast::RawForecastResponse>()
             .await
-            .map_err(|_| {
-                log::error!("Failed to parse forecast API response");
+            .map_err(|e| {
+                log::error!("Failed to parse forecast API response: {e}");
                 ApiError::InvalidResponse
             })?;
         Ok(crate::weather_api::forecast::aggregate_daily(raw))
@@ -334,14 +341,108 @@ impl WeatherProvider for OpenWeatherProvider {
         let api_location = location_config_to_location(location);
         get_forecast(&api_location, &self.api_key).await
     }
+}
 
-    /// Returns the display name of the provider.
-    fn name(&self) -> &'static str {
-        "OpenWeather"
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_weather_symbol_known_conditions() {
+        assert_eq!(get_weather_symbol("Clear"), WeatherSymbol::Clear);
+        assert_eq!(get_weather_symbol("Rain"), WeatherSymbol::Rain);
+        assert_eq!(
+            get_weather_symbol("Thunderstorm"),
+            WeatherSymbol::Thunderstorm
+        );
+        assert_eq!(get_weather_symbol("Tornado"), WeatherSymbol::Tornado);
     }
 
-    /// Returns `true` as this provider requires an API key.
-    fn requires_api_key(&self) -> bool {
-        true
+    #[test]
+    fn test_get_weather_symbol_unknown_falls_back_to_default() {
+        assert_eq!(
+            get_weather_symbol("SomethingUnknown"),
+            WeatherSymbol::Default
+        );
+        assert_eq!(get_weather_symbol(""), WeatherSymbol::Default);
+    }
+
+    #[test]
+    fn test_select_location_empty_is_not_found() {
+        let result = select_location(vec![]);
+        assert!(matches!(result, Err(GeocodeError::LocationNotFound)));
+    }
+
+    #[test]
+    fn test_select_location_picks_first_result() {
+        let locations = vec![
+            Location {
+                name: "Peoria".to_string(),
+                lat: 40.6936,
+                lon: -89.589,
+                country: Some("US".to_string()),
+                state: Some("IL".to_string()),
+            },
+            Location {
+                name: "Peoria".to_string(),
+                lat: 33.5806,
+                lon: -112.2374,
+                country: Some("US".to_string()),
+                state: Some("AZ".to_string()),
+            },
+        ];
+        let selected = select_location(locations).unwrap();
+        assert_eq!(selected.state.as_deref(), Some("IL"));
+    }
+
+    #[test]
+    fn test_location_deserializes_from_geocode_fixture() {
+        // Matches the shape of OpenWeatherMap's geo/1.0/direct response.
+        let json = r#"[{
+            "name": "Peoria",
+            "lat": 40.6936,
+            "lon": -89.589,
+            "country": "US",
+            "state": "Illinois"
+        }]"#;
+        let locations: Vec<Location> = serde_json::from_str(json).unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].name, "Peoria");
+        assert_eq!(locations[0].state.as_deref(), Some("Illinois"));
+    }
+
+    #[test]
+    fn test_location_deserializes_empty_geocode_fixture() {
+        // OpenWeatherMap returns an empty array (not an error) when nothing matches.
+        let locations: Vec<Location> = serde_json::from_str("[]").unwrap();
+        assert!(locations.is_empty());
+    }
+
+    #[test]
+    fn test_api_response_deserializes_from_fixture() {
+        // Matches the shape of OpenWeatherMap's data/2.5/weather response.
+        let json = r#"{
+            "weather": [{"main": "Clear", "description": "clear sky"}],
+            "main": {
+                "temp": 22.5,
+                "feels_like": 22.0,
+                "temp_min": 19.0,
+                "temp_max": 25.0,
+                "pressure": 1015,
+                "humidity": 65
+            },
+            "wind": {"speed": 3.6, "deg": 210},
+            "visibility": 10000,
+            "sys": {"sunrise": 1700000000, "sunset": 1700040000},
+            "timezone": -18000,
+            "name": "Peoria"
+        }"#;
+        let response: ApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.name, "Peoria");
+        assert_eq!(response.weather[0].main, "Clear");
+        assert_eq!(response.main.temp, 22.5);
+        assert_eq!(response.wind.deg, 210);
+        assert_eq!(response.sys.sunrise, 1_700_000_000);
+        assert_eq!(response.timezone, -18000);
     }
 }

--- a/src/weather_api/weather_provider.rs
+++ b/src/weather_api/weather_provider.rs
@@ -40,14 +40,6 @@ pub trait WeatherProvider {
     /// # Errors
     /// Returns an `ApiError` if the data cannot be fetched.
     async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError>;
-
-    /// Returns the display name of the weather provider (e.g., "OpenWeather").
-    #[allow(dead_code)]
-    fn name(&self) -> &'static str;
-
-    /// Returns `true` if the provider requires an API key to function.
-    #[allow(dead_code)]
-    fn requires_api_key(&self) -> bool;
 }
 
 /// A factory for creating weather providers.


### PR DESCRIPTION
## Summary

Closes #8. Four concrete items from that issue's research/audit comment:

- **Test coverage**: `openweather_api.rs` had zero tests (unlike `google_weather_api.rs`'s 8). Added 7 fixture-based tests. Extracted `select_location()` out of `get_coords()` so the empty-array/first-result selection logic is testable without a live network call.
- **Dead code removed**: `WeatherProvider::name()`/`requires_api_key()` — both carried `#[allow(dead_code)]`, and nothing outside `weather_api/` called either one. The API-token requirement they described is already enforced directly in `WeatherProviderFactory::create_provider`.
- **Connection reuse**: `GoogleWeatherProvider` now holds one `reqwest::Client`, reused across its geocode/currentConditions/forecast calls, instead of constructing a fresh client per request.
- **Error detail preserved**: `openweather_api.rs`'s response-parsing failures now log the actual underlying error instead of discarding it via `map_err(|_| ...)`, consistent with how `google_weather_api.rs` already logs its own parse failures.

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all` (34 tests, incl. 7 new `openweather_api` tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Verified live against both real APIs after the refactor (`cargo run --example openweather_test` / `google_weather_test`) to confirm the client-reuse change didn't alter request behavior