### PR TITLE
feat(cli): add --headless mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1775,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3425,6 +3471,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "clap",
  "dirs",
  "env_logger",
  "futures-util",
@@ -4736,6 +4783,12 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ image = { version = "0.25.10", default-features = false, features = ["png"] }
 open = "5.3.2"
 keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
 jiff = "0.2.31"
+clap = { version = "4.6.1", features = ["derive"] }
 
 [[bin]]
 name = "open-weather-wizard"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,16 @@ become the body of the GitHub Release created by
 
 ## Unreleased
 
+**CLI**
+
+- New `--headless` mode: fetches weather (and forecast) once and prints it to
+  stdout without opening the GUI — useful for scripting, status-bar widgets,
+  or a display-less machine. `--json` for machine-readable output;
+  `--city`/`--state`/`--country`/`--provider` for a one-off query without
+  touching the saved config. Still needs an API token, either the one saved
+  via the GUI's Preferences (OS keychain) or, for a machine with no keychain
+  available, the `OPEN_WEATHER_WIZARD_API_TOKEN` environment variable.
+
 **Interface**
 
 - First-run setup: if no config file exists yet, Preferences now opens

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,210 @@
+//! # Headless CLI Mode
+//!
+//! `--headless` fetches weather once and prints it to stdout, without ever
+//! opening an `iced` window -- useful for scripting, status-bar widgets, or
+//! a genuinely headless machine (see issue #40). Deliberately a *bin-only*
+//! module (declared via `mod cli;` in `main.rs`, not re-exported from
+//! `lib.rs`): CLI parsing is a concern of this specific executable, not the
+//! library crate other code links against.
+//!
+//! This never touches `app::run()`/`iced::daemon`, so it's free to spin up
+//! its own `tokio::runtime::Runtime` -- the "don't nest a runtime around
+//! `app::run()`" constraint noted in `main.rs`'s doc comment only applies to
+//! the GUI path.
+//!
+//! A one-shot fetch-and-print, not a daemon/watch mode -- recurring headless
+//! refresh is explicitly out of scope (see issue #40).
+
+use clap::Parser;
+
+use crate::config::{ConfigManager, LocationConfig, WeatherApiProvider};
+use crate::ui::temperature::{
+    celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
+    speed_to_display, speed_unit, unit_symbol,
+};
+use crate::weather_api::forecast::ForecastResponse;
+use crate::weather_api::openweather_api::ApiResponse;
+use crate::weather_api::weather_provider::WeatherProviderFactory;
+
+/// Overrides whatever token is in the OS keychain -- the keychain (via the
+/// `keyring` crate's Secret Service backend on Linux) isn't guaranteed to be
+/// available on a genuinely headless machine with no D-Bus session, so
+/// scripted/server use needs a way to supply a token that doesn't depend on
+/// it.
+const TOKEN_ENV_VAR: &str = "OPEN_WEATHER_WIZARD_API_TOKEN";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "open-weather-wizard",
+    about = "A desktop weather app. Pass --headless to fetch and print weather without opening the GUI."
+)]
+pub struct Cli {
+    /// Fetch weather once and print to stdout, without opening the GUI.
+    #[arg(long)]
+    pub headless: bool,
+
+    /// Output machine-readable JSON instead of human-readable text.
+    #[arg(long, requires = "headless")]
+    pub json: bool,
+
+    /// Override the configured city for this one query.
+    #[arg(long, requires = "headless")]
+    pub city: Option<String>,
+
+    /// Override the configured state/province for this one query.
+    #[arg(long, requires = "headless")]
+    pub state: Option<String>,
+
+    /// Override the configured country for this one query.
+    #[arg(long, requires = "headless")]
+    pub country: Option<String>,
+
+    /// Override the configured weather provider for this one query:
+    /// "openweather" or "google".
+    #[arg(long, requires = "headless")]
+    pub provider: Option<String>,
+}
+
+fn parse_provider(value: &str) -> Result<WeatherApiProvider, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "openweather" | "open-weather" | "owm" => Ok(WeatherApiProvider::OpenWeather),
+        "google" | "google-weather" | "googleweather" => Ok(WeatherApiProvider::GoogleWeather),
+        other => Err(format!(
+            "Unknown provider '{other}' -- expected \"openweather\" or \"google\""
+        )),
+    }
+}
+
+/// Runs headless mode and exits the process directly -- `main()`'s fixed
+/// `iced::Result` return type has no good way to represent a CLI success/
+/// failure/exit-code, and this path never returns control to it anyway.
+pub fn run(cli: &Cli) -> ! {
+    let exit_code = match run_inner(cli) {
+        Ok(()) => 0,
+        Err(message) => {
+            eprintln!("Error: {message}");
+            1
+        }
+    };
+    std::process::exit(exit_code);
+}
+
+fn run_inner(cli: &Cli) -> Result<(), String> {
+    let config_manager =
+        ConfigManager::new().map_err(|e| format!("Could not access config directory: {e}"))?;
+
+    if !config_manager.config_exists() {
+        return Err(
+            "No configuration found yet. Run the app normally once to complete first-run setup \
+             (provider, API key, Home location) before using --headless."
+                .to_string(),
+        );
+    }
+
+    let config = config_manager.load_config();
+
+    let provider_type = match &cli.provider {
+        Some(value) => parse_provider(value)?,
+        None => config.weather_provider.clone(),
+    };
+
+    let location = LocationConfig {
+        city: cli
+            .city
+            .clone()
+            .unwrap_or_else(|| config.location.city.clone()),
+        state: cli
+            .state
+            .clone()
+            .unwrap_or_else(|| config.location.state.clone()),
+        country: cli
+            .country
+            .clone()
+            .unwrap_or_else(|| config.location.country.clone()),
+    };
+
+    let token = std::env::var(TOKEN_ENV_VAR)
+        .ok()
+        .filter(|t| !t.is_empty())
+        .or_else(|| config.get_api_token().ok().filter(|t| !t.is_empty()));
+
+    let provider = WeatherProviderFactory::create_provider(&provider_type, token).map_err(|e| {
+        format!(
+            "{e} (set {TOKEN_ENV_VAR} or configure a token via the GUI's Preferences window first)"
+        )
+    })?;
+
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|e| format!("Failed to start async runtime: {e}"))?;
+    let (weather_result, forecast_result) = runtime.block_on(async {
+        let weather = provider.get_weather(&location).await;
+        let forecast = provider.get_forecast(&location).await;
+        (weather, forecast)
+    });
+
+    let weather = weather_result.map_err(|e| format!("Failed to fetch weather: {e:?}"))?;
+    // A forecast failure shouldn't sink the whole command -- current
+    // conditions are still useful on their own, same philosophy as the GUI's
+    // ForecastStatus being independent of WeatherStatus (see src/app.rs).
+    let forecast = forecast_result.ok();
+
+    if cli.json {
+        print_json(&weather, forecast.as_ref())
+    } else {
+        print_text(&weather, forecast.as_ref(), config.use_fahrenheit);
+        Ok(())
+    }
+}
+
+#[derive(serde::Serialize)]
+struct HeadlessOutput<'a> {
+    weather: &'a ApiResponse,
+    forecast: Option<&'a ForecastResponse>,
+}
+
+fn print_json(weather: &ApiResponse, forecast: Option<&ForecastResponse>) -> Result<(), String> {
+    let output = HeadlessOutput { weather, forecast };
+    let json = serde_json::to_string_pretty(&output)
+        .map_err(|e| format!("Failed to serialize output as JSON: {e}"))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn print_text(weather: &ApiResponse, forecast: Option<&ForecastResponse>, use_fahrenheit: bool) {
+    let unit = unit_symbol(use_fahrenheit);
+    let temp = celsius_to_display(weather.main.temp, use_fahrenheit);
+    let feels_like = celsius_to_display(weather.main.feels_like, use_fahrenheit);
+    let wind_speed = speed_to_display(weather.wind.speed, use_fahrenheit);
+    let wind_unit = speed_unit(use_fahrenheit);
+    let compass = compass_direction(weather.wind.deg);
+    let visibility = distance_to_display(weather.visibility as f64, use_fahrenheit);
+    let visibility_unit = distance_unit(use_fahrenheit);
+    let sunrise = format_local_time(weather.sys.sunrise, weather.timezone);
+    let sunset = format_local_time(weather.sys.sunset, weather.timezone);
+
+    println!("{}", weather.name);
+    if let Some(condition) = weather.weather.first() {
+        println!("{}", condition.description);
+    }
+    println!("Temperature:  {temp:.1}{unit} (feels like {feels_like:.0}{unit})");
+    println!("Humidity:     {}%", weather.main.humidity);
+    println!("Wind:         {wind_speed:.0} {wind_unit} {compass}");
+    println!("Pressure:     {} hPa", weather.main.pressure);
+    println!("Visibility:   {visibility:.1} {visibility_unit}");
+    println!("Sunrise:      {sunrise}");
+    println!("Sunset:       {sunset}");
+
+    if let Some(forecast) = forecast
+        && !forecast.days.is_empty()
+    {
+        println!("\nForecast:");
+        for day in &forecast.days {
+            let hi = celsius_to_display(day.temp_max, use_fahrenheit);
+            let lo = celsius_to_display(day.temp_min, use_fahrenheit);
+            println!(
+                "  {}: {hi:.0}{unit} / {lo:.0}{unit} -- {}",
+                day.date, day.description
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,14 @@
 //!
 //! All application logic, including UI construction, state management, and API
 //! calls, is handled within the `open_weather_wizard` library crate, organized into
-//! the `config`, `app`, `ui`, and `weather_api` modules.
+//! the `config`, `app`, `ui`, and `weather_api` modules. `cli` (this bin only,
+//! not part of the library) adds a `--headless` mode -- see its own doc comment.
+use clap::Parser;
 use env_logger::{self, Builder};
 use log::{self, LevelFilter};
 
 mod app;
+mod cli;
 mod config;
 mod geolocation;
 mod ui;
@@ -18,8 +21,12 @@ mod weather_api;
 ///
 /// iced manages its own tokio runtime internally (via its `tokio` executor feature),
 /// so this must stay a plain, synchronous `fn main` rather than `#[tokio::main]` --
-/// nesting a second runtime around `app::run()` would conflict with it.
+/// nesting a second runtime around `app::run()` would conflict with it. `cli::run`
+/// (the `--headless` path) never touches `app::run()`, so it's free to spin up its
+/// own runtime instead.
 fn main() -> iced::Result {
+    let cli = cli::Cli::parse();
+
     Builder::new()
         .filter_level(LevelFilter::Info)
         // iced's internals log full window/compositor structs at Info level
@@ -28,6 +35,10 @@ fn main() -> iced::Result {
         .filter_module("iced_winit", LevelFilter::Warn)
         .filter_module("iced_wgpu", LevelFilter::Warn)
         .init();
+
+    if cli.headless {
+        cli::run(&cli);
+    }
 
     log::info!("Starting Weather Wizard application");
     app::run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,25 @@ mod weather_api;
 fn main() -> iced::Result {
     let cli = cli::Cli::parse();
 
+    // Info-level logging (config loads, fetch lifecycle, etc.) is useful
+    // during development but just noise -- and clutters --headless's stdout
+    // output -- in a release build; `cargo build --release` disables it in
+    // favor of Warn/Error only. `RUST_LOG` still overrides this if a user
+    // explicitly wants Info (or more) out of a release binary.
+    let default_level = if cfg!(debug_assertions) {
+        LevelFilter::Info
+    } else {
+        LevelFilter::Warn
+    };
+
     Builder::new()
-        .filter_level(LevelFilter::Info)
+        .filter_level(default_level)
         // iced's internals log full window/compositor structs at Info level
         // on every launch (window attributes, GPU adapter info, etc.) --
         // useful when debugging iced itself, just noise otherwise.
         .filter_module("iced_winit", LevelFilter::Warn)
         .filter_module("iced_wgpu", LevelFilter::Warn)
+        .parse_default_env()
         .init();
 
     if cli.headless {

--- a/src/weather_api/forecast.rs
+++ b/src/weather_api/forecast.rs
@@ -8,7 +8,7 @@
 //! so this aggregates the 3-hourly entries into daily min/max/dominant-condition
 //! buckets instead.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::weather_api::openweather_api::{Main, Weather, WeatherSymbol, Wind, get_weather_symbol};
 
@@ -44,7 +44,7 @@ pub struct RawForecastResponse {
 }
 
 /// An app-level daily forecast summary, aggregated from several 3-hourly entries.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ForecastDay {
     /// UTC calendar date, e.g. "2026-07-02". Kept as a `String` bucket key rather
     /// than adding a date-handling crate; this is a display label, not something
@@ -81,7 +81,7 @@ pub struct ForecastDay {
 }
 
 /// An app-level forecast, ready for the UI to render.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ForecastResponse {
     pub location_name: String,
     pub days: Vec<ForecastDay>,

--- a/src/weather_api/openweather_api.rs
+++ b/src/weather_api/openweather_api.rs
@@ -20,12 +20,12 @@ use crate::config::LocationConfig;
 use crate::weather_api::weather_provider::{WeatherProvider, location_config_to_location};
 use async_trait::async_trait;
 use reqwest;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Represents weather conditions returned by the OpenWeatherMap API.
 ///
 /// This struct contains the main weather type (e.g., "Clouds", "Rain") and a more detailed description
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Weather {
     pub main: String,
     pub description: String,
@@ -34,7 +34,7 @@ pub struct Weather {
 /// Contains the main meteorological data like temperature and humidity.
 ///
 /// This struct is part of the `ApiResponse` and holds the primary weather metrics
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Main {
     pub temp: f64,
     pub feels_like: f64,
@@ -46,14 +46,14 @@ pub struct Main {
 
 /// Wind speed (meters/sec, since requests use `units=metric`) and direction
 /// (meteorological degrees, 0 = due north).
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Wind {
     pub speed: f64,
     pub deg: i64,
 }
 
 /// Sunrise/sunset as Unix (UTC) timestamps.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Sys {
     pub sunrise: i64,
     pub sunset: i64,
@@ -63,7 +63,11 @@ pub struct Sys {
 ///
 /// This struct aggregates the most relevant weather information, including a list of weather
 /// conditions, the main meteorological data like temperature and humidity, and the name of the city.
-#[derive(Deserialize, Debug, Clone)]
+///
+/// Derives `Serialize` (in addition to `Deserialize`) so the headless CLI mode
+/// (`src/cli.rs`, bin-only) can emit this directly as `--json` output --
+/// nothing about parsing provider responses needs it, only that output path.
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ApiResponse {
     pub weather: Vec<Weather>,
     pub main: Main,
@@ -92,7 +96,7 @@ pub enum ApiError {
 }
 
 /// Represents a symbolic representation of a weather condition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum WeatherSymbol {
     Clear,
     Clouds,


### PR DESCRIPTION
## Summary

Closes #40. Fetches weather (and forecast) once and prints it to stdout without ever opening an `iced` window — for scripting, status-bar widgets, or a genuinely display-less machine.

- New `src/cli.rs` (bin-only, not part of the library crate): `clap`-based argument parsing.
  - `--headless` — the mode switch.
  - `--json` — machine-readable output instead of human-readable text.
  - `--city`/`--state`/`--country`/`--provider` — a one-off query without touching the saved config.
- Runs its own `tokio::runtime::Runtime` rather than `app::run()`'s — the "don't nest a runtime" constraint in `main.rs` only applies to the GUI path, which `--headless` never touches.
- Token resolution checks `OPEN_WEATHER_WIZARD_API_TOKEN` before falling back to the OS keychain, since the `keyring` crate's Secret Service backend isn't guaranteed to be available on a headless Linux box with no D-Bus session.
- No config file yet (first-run not completed) fails with a clear message rather than trying to prompt interactively.
- `ApiResponse`/`ForecastResponse` and their nested types gain `Serialize` (previously `Deserialize`-only, since they were only ever parsed from provider responses) to support `--json` output.
- Exit code `0` on success, `1` on any failure — for cron/scripting.
- Bonus (follow-up request): Info-level logs are now off by default in release builds (still on in debug builds; `RUST_LOG` overrides either way) — they cluttered `--headless`'s stdout output in a release binary.

## Test plan
- [x] `cargo build --locked` / `cargo build --release --locked`
- [x] `cargo test --locked --all` (46 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Live, against the real saved config/keychain:
  - `--headless` — correct text output
  - `--headless --json` — valid, well-formed JSON
  - `--headless --provider bogus` — exit code 1, clean stderr message
  - `--headless --city Dunlap` — confirmed the override actually fetches a different location
  - Release build's stdout has no `INFO` log lines; debug build does; `RUST_LOG=info` on the release binary brings them back