### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "open-weather-wizard"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-weather-wizard"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Arunkumar Mourougappane <amouroug.dev@gmail.com>"]
 description = "A simple, elegant desktop weather app with animated Lottie icons, a 5-day forecast, and a silent cross-faded auto-refresh, built in Rust with iced."

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,13 @@
 
 Update this file before pushing a release tag (`vX.Y.Z`) — its contents
 become the body of the GitHub Release created by
-`.github/workflows/release.yml`.
+`.github/workflows/release.yml` (the whole file, verbatim — there's no
+section-extraction, so this should only ever describe the release about to
+ship). Past releases' notes live under
+[`docs/previous_releases/`](docs/previous_releases/) instead of
+accumulating here.
 
-## Unreleased
+## v0.3.0
 
 **CLI**
 
@@ -38,47 +42,3 @@ become the body of the GitHub Release created by
   free tier is capped at 10,000 calls/month, this provider auto-refreshes
   every 15 minutes instead of OpenWeatherMap's 30 seconds. See
   `docs/GOOGLE_WEATHER_API.md` for the full integration details.
-
-## v0.2.0
-
-The GTK4 UI from v0.1.0 is gone — the app is rebuilt from scratch on
-[iced](https://iced.rs), with a redesigned interface and a lot of new
-functionality. See `docs/ARCHITECTURE.md` for the rewrite rationale.
-
-**Interface**
-
-- Redesigned main view: current-conditions card with a color-coded stat
-  grid (feels-like, humidity, wind, pressure, visibility, sunrise/sunset).
-- 5-day forecast as a centered carousel; tap any day to see its detail
-  (hi/lo, feels-like, humidity, wind, pressure, visibility, chance of rain)
-  right in the main card.
-- Every weather condition gets its own animated, GPU-composited Lottie
-  icon (sun, rain, snow, clouds, thunderstorms, drizzle, fog, haze, wind,
-  tornado, and more) rendered directly through iced's `wgpu` surface.
-- Background refresh no longer blanks the screen back to a loading state;
-  changed values cross-fade in place. A shimmer skeleton placeholder is
-  shown only on first load, replacing the old spinner.
-- Dark mode and °C/°F, both live-previewed in Preferences before saving.
-- Preferences and About are now separate windows with validated fields,
-  grouped sections, and a manual Refresh button in the toolbar.
-
-**Providers**
-
-- Two weather providers: live data from OpenWeatherMap, or a built-in
-  Google Weather mock provider that needs no API key.
-- Forecast parsing now includes wind, chance of precipitation, and
-  visibility per day.
-
-**Security**
-
-- The OpenWeatherMap API token is no longer stored as base64 in
-  `config.json` — it now lives in the OS's native credential store
-  (macOS Keychain / Windows Credential Manager / Linux Secret Service).
-  Existing config files are migrated automatically on first load.
-
-**Packaging**
-
-- Releases now include installable app packages alongside the raw
-  binaries: a `.dmg` for macOS, a `.deb` for Linux, and an `.exe` (NSIS)
-  installer for Windows.
-- New app icon.

--- a/docs/previous_releases/v0.2.0.md
+++ b/docs/previous_releases/v0.2.0.md
@@ -1,0 +1,43 @@
+# v0.2.0
+
+The GTK4 UI from v0.1.0 is gone — the app is rebuilt from scratch on
+[iced](https://iced.rs), with a redesigned interface and a lot of new
+functionality. See `docs/ARCHITECTURE.md` for the rewrite rationale.
+
+**Interface**
+
+- Redesigned main view: current-conditions card with a color-coded stat
+  grid (feels-like, humidity, wind, pressure, visibility, sunrise/sunset).
+- 5-day forecast as a centered carousel; tap any day to see its detail
+  (hi/lo, feels-like, humidity, wind, pressure, visibility, chance of rain)
+  right in the main card.
+- Every weather condition gets its own animated, GPU-composited Lottie
+  icon (sun, rain, snow, clouds, thunderstorms, drizzle, fog, haze, wind,
+  tornado, and more) rendered directly through iced's `wgpu` surface.
+- Background refresh no longer blanks the screen back to a loading state;
+  changed values cross-fade in place. A shimmer skeleton placeholder is
+  shown only on first load, replacing the old spinner.
+- Dark mode and °C/°F, both live-previewed in Preferences before saving.
+- Preferences and About are now separate windows with validated fields,
+  grouped sections, and a manual Refresh button in the toolbar.
+
+**Providers**
+
+- Two weather providers: live data from OpenWeatherMap, or a built-in
+  Google Weather mock provider that needs no API key.
+- Forecast parsing now includes wind, chance of precipitation, and
+  visibility per day.
+
+**Security**
+
+- The OpenWeatherMap API token is no longer stored as base64 in
+  `config.json` — it now lives in the OS's native credential store
+  (macOS Keychain / Windows Credential Manager / Linux Secret Service).
+  Existing config files are migrated automatically on first load.
+
+**Packaging**
+
+- Releases now include installable app packages alongside the raw
+  binaries: a `.dmg` for macOS, a `.deb` for Linux, and an `.exe` (NSIS)
+  installer for Windows.
+- New app icon.


### PR DESCRIPTION
## Summary

Part of #51. All other v0.3.0-milestoned issues (#8, #35, #38, #40, #50) are closed and merged into `main` — this is the release-prep work itself.

- Bump `Cargo.toml`/`Cargo.lock` version from `0.2.0` to `0.3.0`.
- Consolidate `RELEASE_NOTES.md`'s `## Unreleased` into `## v0.3.0`.
- **New convention**: move the old `## v0.2.0` section out to `docs/previous_releases/v0.2.0.md`, and stop accumulating historical releases in `RELEASE_NOTES.md` going forward. `.github/workflows/release.yml`'s `gh release create --notes-file RELEASE_NOTES.md` uses the whole file verbatim as the GitHub Release body (no section-extraction), so keeping only the current release's notes there is what makes each tagged release's page show only its own notes instead of restating the whole project history every time.

## Test plan
- [x] `cargo build --locked` / `cargo test --locked --all` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt -- --check` — all pass with the version bump
- [x] Confirmed `packaging/macos/Info.plist` is correctly wired into `Cargo.toml`'s `package.metadata.packager.macos` section for the release workflow's macOS packaging step (already verified end-to-end locally during the geolocation work — building and mounting the `.dmg` confirmed the Info.plist key was baked in)
- [ ] **Not done here on purpose**: tagging and pushing `v0.3.0`. That's the actual release trigger (kicks off real CI builds across three platforms and publishes a real GitHub Release with real binaries) — a separate, deliberate step after this PR merges, not bundled into it.