### PR TITLE
fix(ui): respect °F/°C toggle for pressure display

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,14 @@ ship). Past releases' notes live under
 [`docs/previous_releases/`](docs/previous_releases/) instead of
 accumulating here.
 
+## Unreleased
+
+**Bug fixes**
+
+- Pressure now respects the °F/°C unit toggle like every other stat: hPa in
+  metric mode, inHg in imperial mode. Previously it was hardcoded to hPa
+  regardless of the preference. (#42)
+
 ## v0.3.0
 
 **CLI**

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,7 @@ use iced::{Element, Size, Subscription, Task, Theme, window};
 use crate::config::{AppConfig, ConfigManager, LocationConfig, WeatherApiProvider};
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
-    speed_to_display, speed_unit, unit_symbol,
+    pressure_to_display, pressure_unit, speed_to_display, speed_unit, unit_symbol,
 };
 use crate::ui::{about, main_screen, preferences, transition};
 use crate::weather_api::forecast::ForecastResponse;
@@ -216,6 +216,9 @@ fn note_weather_transitions(
     let compass = compass_direction(response.wind.deg);
     let visibility = distance_to_display(response.visibility as f64, use_fahrenheit);
     let visibility_unit = distance_unit(use_fahrenheit);
+    let pressure = pressure_to_display(response.main.pressure, use_fahrenheit);
+    let pressure_unit_str = pressure_unit(use_fahrenheit);
+    let pressure_precision = if use_fahrenheit { 2 } else { 0 };
     let sunrise = format_local_time(response.sys.sunrise, response.timezone);
     let sunset = format_local_time(response.sys.sunset, response.timezone);
 
@@ -223,7 +226,10 @@ fn note_weather_transitions(
     tracker.note("feels_like", &format!("{:.0}{unit}", feels_like));
     tracker.note("humidity", &format!("{}%", response.main.humidity));
     tracker.note("wind", &format!("{:.0} {wind_unit} {compass}", wind_speed));
-    tracker.note("pressure", &format!("{} hPa", response.main.pressure));
+    tracker.note(
+        "pressure",
+        &format!("{:.*} {pressure_unit_str}", pressure_precision, pressure),
+    );
     tracker.note(
         "visibility",
         &format!("{:.1} {visibility_unit}", visibility),

--- a/src/ui/main_screen.rs
+++ b/src/ui/main_screen.rs
@@ -13,7 +13,7 @@ use crate::app::{AppState, ForecastStatus, Message, WeatherStatus};
 use crate::config::WeatherApiProvider;
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
-    speed_to_display, speed_unit, unit_symbol,
+    pressure_to_display, pressure_unit, speed_to_display, speed_unit, unit_symbol,
 };
 use crate::ui::transition::ValueTracker;
 use crate::ui::{forecast_row, icons, skeleton, style};
@@ -283,6 +283,9 @@ fn stats_view_forecast(day: &ForecastDay, use_fahrenheit: bool) -> Element<'_, M
     let compass = compass_direction(day.wind_deg);
     let visibility = distance_to_display(day.visibility as f64, use_fahrenheit);
     let visibility_unit = distance_unit(use_fahrenheit);
+    let pressure = pressure_to_display(day.pressure, use_fahrenheit);
+    let pressure_unit_str = pressure_unit(use_fahrenheit);
+    let pressure_precision = if use_fahrenheit { 2 } else { 0 };
 
     column![
         row![
@@ -320,10 +323,13 @@ fn stats_view_forecast(day: &ForecastDay, use_fahrenheit: bool) -> Element<'_, M
                 "\u{2696}",
                 style::STAT_PRESSURE,
                 "Pressure",
-                text(format!("{} hPa", day.pressure))
-                    .size(15)
-                    .font(BOLD)
-                    .into(),
+                text(format!(
+                    "{:.*} {pressure_unit_str}",
+                    pressure_precision, pressure
+                ))
+                .size(15)
+                .font(BOLD)
+                .into(),
             ),
         ]
         .spacing(10),
@@ -375,6 +381,10 @@ fn stats_view<'a>(
     let visibility = distance_to_display(weather_data.visibility as f64, use_fahrenheit);
     let visibility_unit = distance_unit(use_fahrenheit);
 
+    let pressure = pressure_to_display(weather_data.main.pressure, use_fahrenheit);
+    let pressure_unit_str = pressure_unit(use_fahrenheit);
+    let pressure_precision = if use_fahrenheit { 2 } else { 0 };
+
     let sunrise = format_local_time(weather_data.sys.sunrise, weather_data.timezone);
     let sunset = format_local_time(weather_data.sys.sunset, weather_data.timezone);
 
@@ -425,7 +435,7 @@ fn stats_view<'a>(
                 "Pressure",
                 tracker.cross_fade(
                     "pressure",
-                    format!("{} hPa", weather_data.main.pressure),
+                    format!("{:.*} {pressure_unit_str}", pressure_precision, pressure),
                     15,
                     BOLD,
                     style::default_text,

--- a/src/ui/temperature.rs
+++ b/src/ui/temperature.rs
@@ -45,6 +45,20 @@ pub fn distance_unit(fahrenheit: bool) -> &'static str {
     if fahrenheit { "mi" } else { "km" }
 }
 
+/// Pressure is always fetched in hPa; converts to inHg for the imperial
+/// preference (1 hPa = 0.02953 inHg).
+pub fn pressure_to_display(hpa: i64, fahrenheit: bool) -> f64 {
+    if fahrenheit {
+        hpa as f64 * 0.02953
+    } else {
+        hpa as f64
+    }
+}
+
+pub fn pressure_unit(fahrenheit: bool) -> &'static str {
+    if fahrenheit { "inHg" } else { "hPa" }
+}
+
 /// Meteorological degrees (0 = due north, clockwise) to a 16-point compass
 /// abbreviation.
 pub fn compass_direction(deg: i64) -> &'static str {


### PR DESCRIPTION
## Summary
- Pressure was hardcoded to hPa in `stats_view`, `stats_view_forecast`, and `note_weather_transitions`'s cross-fade tracking, unlike temperature, wind speed, and visibility, which all switch units with the `use_fahrenheit` preference.
- Adds `pressure_to_display`/`pressure_unit` to `src/ui/temperature.rs` (1 hPa = 0.02953 inHg), following the existing `speed_to_display`/`distance_to_display` pattern.
- Updates all three call sites to display inHg when the imperial preference is active.

Closes #42

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`