### PR TITLE
feat(preferences): add a 'Test connection' button

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,14 @@ accumulating here.
 
 ## Unreleased
 
+**Interface**
+
+- Preferences now has a "Verify API" button next to the API Token field:
+  fires a single live request against the currently-typed
+  provider/token/location (not the saved config) and shows an inline
+  "✔ Connected" / "✗ <error>" result, so a bad token surfaces right next to
+  the field instead of only after Save closes the window. (#43)
+
 **Bug fixes**
 
 - Pressure now respects the °F/°C unit toggle like every other stat: hPa in

--- a/src/app.rs
+++ b/src/app.rs
@@ -167,18 +167,34 @@ pub enum Message {
     /// see `update`. Purely informational -- never touches `state.weather`
     /// or `state.config`.
     ConnectionTested(Result<(), String>),
+    /// Result of the async, off-UI-thread `AppConfig::get_api_token` read
+    /// fired whenever a Preferences window opens (`OpenPreferences`, and
+    /// `boot`'s first-run path) -- see `preferences::State::from_config`'s
+    /// docs for why the read isn't done synchronously up front. Applies to
+    /// whatever Preferences window is currently open, if any; a no-op if
+    /// it's already been closed by the time this resolves.
+    ApiTokenLoaded(String),
 
     Preferences(preferences::Message),
 }
 
 /// Builds a `Task` that fetches current weather for the active provider/location.
+///
+/// `AppConfig::get_api_token` is a blocking OS keychain read (and, on macOS,
+/// can pop a permission prompt the *first* time a given build accesses it,
+/// or every time if the user picked "Allow" over "Always Allow") -- calling
+/// it before entering the `async move` block would run it synchronously on
+/// `update()`'s own thread, freezing the whole UI (including button clicks)
+/// until that prompt is dismissed. Reading it inside the async block instead
+/// keeps it on iced's executor, off the UI thread.
 fn fetch_weather_task(config: &AppConfig) -> Task<Message> {
     let provider_type = config.weather_provider.clone();
     let location = config.location.clone();
-    let token = config.get_api_token().ok();
+    let config = config.clone();
 
     Task::perform(
         async move {
+            let token = config.get_api_token().ok();
             let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
             provider
                 .get_weather(&location)
@@ -190,13 +206,16 @@ fn fetch_weather_task(config: &AppConfig) -> Task<Message> {
 }
 
 /// Builds a `Task` that fetches a forecast for the active provider/location.
+/// See `fetch_weather_task`'s docs for why the token is read inside the
+/// async block rather than before it.
 fn fetch_forecast_task(config: &AppConfig) -> Task<Message> {
     let provider_type = config.weather_provider.clone();
     let location = config.location.clone();
-    let token = config.get_api_token().ok();
+    let config = config.clone();
 
     Task::perform(
         async move {
+            let token = config.get_api_token().ok();
             let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
             provider
                 .get_forecast(&location)
@@ -204,6 +223,18 @@ fn fetch_forecast_task(config: &AppConfig) -> Task<Message> {
                 .map_err(|e| format!("{:?}", e))
         },
         Message::ForecastFetched,
+    )
+}
+
+/// Builds a `Task` that reads the API token off the UI thread and reports
+/// it back via `Message::ApiTokenLoaded` -- see
+/// `preferences::State::from_config`'s docs for why Preferences opens with
+/// an empty token field rather than reading it synchronously up front.
+fn fetch_api_token_task(config: &AppConfig) -> Task<Message> {
+    let config = config.clone();
+    Task::perform(
+        async move { config.get_api_token().unwrap_or_default() },
+        Message::ApiTokenLoaded,
     )
 }
 
@@ -308,7 +339,11 @@ pub fn boot() -> (AppState, Task<Message>) {
         let mut prefs_state = preferences::State::from_config(&config);
         prefs_state.is_first_run = true;
         let (id, prefs_open_task) = window::open(preferences_window_settings());
-        (Some(id), Some(prefs_state), prefs_open_task.discard())
+        (
+            Some(id),
+            Some(prefs_state),
+            Task::batch([prefs_open_task.discard(), fetch_api_token_task(&config)]),
+        )
     } else {
         (
             None,
@@ -423,7 +458,7 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
             state.prefs_state = Some(preferences::State::from_config(&state.config));
             let (id, open_task) = window::open(preferences_window_settings());
             state.prefs_window = Some(id);
-            open_task.discard()
+            Task::batch([open_task.discard(), fetch_api_token_task(&state.config)])
         }
         Message::OpenAbout => {
             if state.about_window.is_some() {
@@ -546,6 +581,14 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                             .to_string(),
                     );
                 }
+            }
+            Task::none()
+        }
+        Message::ApiTokenLoaded(token) => {
+            // Same reasoning as `LocationDetected`: Preferences may already
+            // be closed by the time this async keychain read resolves.
+            if let Some(prefs_state) = state.prefs_state.as_mut() {
+                prefs_state.token_input = token;
             }
             Task::none()
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,11 @@ pub const DEFAULT_WINDOW_HEIGHT: f32 = 620.0;
 const MAIN_WINDOW_MIN_SIZE: Size = Size::new(480.0, 420.0);
 /// The preferences form's fixed 160px label column plus a usable input
 /// width needs at least this much room before fields start getting crushed.
-const PREFERENCES_WINDOW_MIN_SIZE: Size = Size::new(440.0, 400.0);
+/// The height covers all three sections (Weather Provider -- including the
+/// Verify API button/status row -- Home, and Appearance) plus the
+/// Save/Cancel row at once, so the common case (no validation errors, no
+/// first-run banner) never needs `view()`'s `scrollable` wrapper to kick in.
+const PREFERENCES_WINDOW_MIN_SIZE: Size = Size::new(460.0, 640.0);
 const AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 /// A full refresh against the real Google Weather API costs 3 billable
 /// calls (`currentConditions:lookup` + two `forecast/days:lookup` calls --
@@ -156,6 +160,13 @@ pub enum Message {
     /// Applies to whatever Preferences window is currently open, if any --
     /// see `update`.
     LocationDetected(Result<LocationConfig, String>),
+    /// Result of a single `get_weather()` call against the *currently-typed*
+    /// provider/token/location, fired by
+    /// `Message::Preferences(preferences::Message::TestConnectionRequested)`.
+    /// Applies to whatever Preferences window is currently open, if any --
+    /// see `update`. Purely informational -- never touches `state.weather`
+    /// or `state.config`.
+    ConnectionTested(Result<(), String>),
 
     Preferences(preferences::Message),
 }
@@ -267,7 +278,7 @@ fn note_forecast_transitions(
 /// paths can never drift apart.
 fn preferences_window_settings() -> window::Settings {
     window::Settings {
-        size: Size::new(520.0, 560.0),
+        size: Size::new(540.0, 700.0),
         min_size: Some(PREFERENCES_WINDOW_MIN_SIZE),
         icon: crate::ui::icons::load_window_icon("icon/icon.png"),
         ..window::Settings::default()
@@ -536,6 +547,47 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                     );
                 }
             }
+            Task::none()
+        }
+        Message::Preferences(preferences::Message::TestConnectionRequested) => {
+            let Some(prefs_state) = state.prefs_state.as_mut() else {
+                return Task::none();
+            };
+            prefs_state.is_testing_connection = true;
+            prefs_state.connection_test_result = None;
+
+            let provider_type = prefs_state.provider.clone();
+            let token =
+                (!prefs_state.token_input.is_empty()).then(|| prefs_state.token_input.clone());
+            let location = LocationConfig {
+                city: prefs_state.city_input.clone(),
+                state: prefs_state.state_input.clone(),
+                country: prefs_state.country_input.clone(),
+            };
+
+            Task::perform(
+                async move {
+                    let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+                    provider
+                        .get_weather(&location)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| format!("{:?}", e))
+                },
+                Message::ConnectionTested,
+            )
+        }
+        Message::ConnectionTested(result) => {
+            // Same reasoning as `LocationDetected`: Preferences may already
+            // be closed by the time this async call resolves.
+            let Some(prefs_state) = state.prefs_state.as_mut() else {
+                return Task::none();
+            };
+            prefs_state.is_testing_connection = false;
+            if let Err(e) = &result {
+                log::warn!("Connection test failed: {e}");
+            }
+            prefs_state.connection_test_result = Some(result);
             Task::none()
         }
         Message::Preferences(sub_message) => {

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -48,6 +48,15 @@ pub struct State {
     /// convenience prefill, not a required step; the fields can always be
     /// typed in by hand instead.
     pub location_detection_error: Option<String>,
+    /// Whether a connection test (`Message::TestConnectionRequested`,
+    /// intercepted by `app::update`) is currently in flight -- disables the
+    /// "Verify API" button and swaps its label, same idea as
+    /// `is_detecting_location`.
+    pub is_testing_connection: bool,
+    /// Result of the last connection test, cleared on the next attempt.
+    /// Purely informational -- never blocks Save, same philosophy as
+    /// location detection being best-effort.
+    pub connection_test_result: Option<Result<(), String>>,
 }
 
 impl State {
@@ -63,6 +72,8 @@ impl State {
             is_first_run: false,
             is_detecting_location: false,
             location_detection_error: None,
+            is_testing_connection: false,
+            connection_test_result: None,
         }
     }
 
@@ -124,14 +135,21 @@ pub enum Message {
     /// firing an async `Task` isn't something this module's synchronous
     /// `update` can do itself.
     DetectLocationRequested,
+    /// The "Verify API" button -- intercepted by the parent, which
+    /// builds a provider from the *currently-typed* provider/token/location
+    /// (not the saved config), fires a single `get_weather()` call, and
+    /// reports back via the app-level `Message::ConnectionTested`, since
+    /// firing an async `Task` isn't something this module's synchronous
+    /// `update` can do itself.
+    TestConnectionRequested,
     Save,
     Cancel,
 }
 
 /// Mutates field-edit messages; `Save`/`Cancel`/`OpenUrl`/
-/// `DetectLocationRequested` are intercepted by the parent `AppState::update`
-/// (see `src/app.rs`) since they need access to `AppConfig`/the OS's URL
-/// opener/an async `Task` respectively.
+/// `DetectLocationRequested`/`TestConnectionRequested` are intercepted by the
+/// parent `AppState::update` (see `src/app.rs`) since they need access to
+/// `AppConfig`/the OS's URL opener/an async `Task` respectively.
 pub fn update(state: &mut State, message: Message) {
     match message {
         Message::ProviderSelected(provider) => state.provider = provider,
@@ -143,6 +161,7 @@ pub fn update(state: &mut State, message: Message) {
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
         Message::OpenUrl(_)
         | Message::DetectLocationRequested
+        | Message::TestConnectionRequested
         | Message::Save
         | Message::Cancel => {
             // Handled by the parent; nothing to do locally.
@@ -169,30 +188,40 @@ fn api_key_hint(provider: &WeatherApiProvider) -> (&'static str, &'static str) {
 pub fn view(state: &State) -> Element<'_, Message> {
     let (hint_label, hint_url) = api_key_hint(&state.provider);
 
-    let provider_section = section(
-        "\u{2699} Weather Provider",
-        column![
-            labeled_row(
-                "Provider:",
-                pick_list(
-                    PROVIDERS,
-                    Some(state.provider.clone()),
-                    Message::ProviderSelected
-                )
+    let connected = matches!(state.connection_test_result, Some(Ok(())));
+
+    let mut provider_column = column![
+        labeled_row(
+            "Provider:",
+            pick_list(
+                PROVIDERS,
+                Some(state.provider.clone()),
+                Message::ProviderSelected
+            )
+            .into()
+        ),
+        labeled_row(
+            "API Token:",
+            text_input("Enter your API token", &state.token_input)
+                .secure(true)
+                .on_input(Message::TokenChanged)
                 .into()
-            ),
-            labeled_row(
-                "API Token:",
-                text_input("Enter your API token", &state.token_input)
-                    .secure(true)
-                    .on_input(Message::TokenChanged)
-                    .into()
-            ),
-            api_key_hint_row(hint_label, hint_url),
-        ]
-        .spacing(12)
-        .into(),
-    );
+        ),
+        api_key_hint_row(hint_label, hint_url),
+        test_connection_row(state.is_testing_connection, connected),
+    ]
+    .spacing(12);
+
+    if let Some(Err(e)) = &state.connection_test_result {
+        provider_column = provider_column.push(location_hint_row(
+            text(format!("\u{2717} {e}"))
+                .size(12)
+                .style(style::danger)
+                .into(),
+        ));
+    }
+
+    let provider_section = section("\u{2699} Weather Provider", provider_column.into());
 
     let mut location_column = column![
         labeled_row(
@@ -335,6 +364,7 @@ fn api_key_hint_row(label: &'static str, url: &'static str) -> Element<'static, 
             .style(style::link_button)
             .padding(0),
     ]
+    .spacing(12)
     .into()
 }
 
@@ -343,7 +373,9 @@ fn api_key_hint_row(label: &'static str, url: &'static str) -> Element<'static, 
 /// `labeled_row`'s 160px label width) -- used for the location-detection
 /// error line, which isn't itself a button/link like the other hint rows.
 fn location_hint_row(content: Element<'_, Message>) -> Element<'_, Message> {
-    row![space::horizontal().width(160), content].into()
+    row![space::horizontal().width(160), content]
+        .spacing(12)
+        .into()
 }
 
 /// The "Detect my location" button, indented to align under the Home
@@ -363,4 +395,33 @@ fn detect_location_row(is_detecting: bool) -> Element<'static, Message> {
     ]
     .align_y(Alignment::Center)
     .into()
+}
+
+/// The "Verify API" button, indented to align under the API Token
+/// field -- same pattern as `detect_location_row`. A successful result is
+/// shown inline right next to the button (rather than a full row below,
+/// like the error case in `view`) since "\u{2714} Connected" is short
+/// enough to never wrap. Uses the plain Heavy Check Mark glyph (colored via
+/// `style::success`) rather than the ✅ emoji -- iced's text renderer draws
+/// glyphs from the system's default font, and color emoji isn't guaranteed
+/// to render in full color there, unlike a typographic glyph.
+fn test_connection_row(is_testing: bool, connected: bool) -> Element<'static, Message> {
+    let mut content = row![
+        space::horizontal().width(160),
+        button(text(if is_testing {
+            "Verifying..."
+        } else {
+            "Verify API"
+        }))
+        .on_press_maybe((!is_testing).then_some(Message::TestConnectionRequested))
+        .style(style::accent_button),
+    ]
+    .spacing(12)
+    .align_y(Alignment::Center);
+
+    if connected {
+        content = content.push(text("\u{2714} Connected").size(13).style(style::success));
+    }
+
+    content.into()
 }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -60,10 +60,21 @@ pub struct State {
 }
 
 impl State {
+    /// Builds the form's initial state from the persisted config -- except
+    /// `token_input`, deliberately left empty here rather than reading it
+    /// synchronously via `AppConfig::get_api_token`. That's a blocking OS
+    /// keychain call that can pop a permission prompt (macOS re-prompts per
+    /// build, or every time if the user picked "Allow" over "Always
+    /// Allow"); calling it here would run it on `app::update`'s own thread
+    /// and freeze the whole UI -- including the window that's about to
+    /// open -- until any hidden/background prompt is dismissed. The caller
+    /// (`app::update`'s `OpenPreferences` handler and `boot`) instead fires
+    /// an async `Task` to read it off-thread and fills it in once resolved
+    /// via `Message::ApiTokenLoaded`.
     pub fn from_config(config: &AppConfig) -> Self {
         Self {
             provider: config.weather_provider.clone(),
-            token_input: config.get_api_token().unwrap_or_default(),
+            token_input: String::new(),
             city_input: config.location.city.clone(),
             state_input: config.location.state.clone(),
             country_input: config.location.country.clone(),

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -198,6 +198,7 @@ pub fn view(state: &State) -> Element<'_, Message> {
                 Some(state.provider.clone()),
                 Message::ProviderSelected
             )
+            .style(style::pick_list)
             .into()
         ),
         labeled_row(
@@ -205,6 +206,7 @@ pub fn view(state: &State) -> Element<'_, Message> {
             text_input("Enter your API token", &state.token_input)
                 .secure(true)
                 .on_input(Message::TokenChanged)
+                .style(style::text_input)
                 .into()
         ),
         api_key_hint_row(hint_label, hint_url),
@@ -228,18 +230,21 @@ pub fn view(state: &State) -> Element<'_, Message> {
             "City:",
             text_input("Enter city name", &state.city_input)
                 .on_input(Message::CityChanged)
+                .style(style::text_input)
                 .into()
         ),
         labeled_row(
             "State/Province:",
             text_input("Enter state or province", &state.state_input)
                 .on_input(Message::StateChanged)
+                .style(style::text_input)
                 .into()
         ),
         labeled_row(
             "Country:",
             text_input("Enter country code (e.g., US, CA)", &state.country_input)
                 .on_input(Message::CountryChanged)
+                .style(style::text_input)
                 .into()
         ),
         detect_location_row(state.is_detecting_location),

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -9,6 +9,11 @@
 use iced::widget::{button, container, text};
 use iced::{Background, Border, Color, Shadow, Theme, Vector};
 
+/// The corner radius shared by every form field (`text_input`/`pick_list`)
+/// and button, so inputs and actions read as one consistent, rounded style
+/// instead of iced's default 2px -- almost-square -- corners.
+const FIELD_RADIUS: f32 = 8.0;
+
 /// Sky-blue accent, used for primary actions and the temperature/location
 /// text -- the two things a glance at the app should land on first. Kept as
 /// a single fixed brand color rather than theme-derived, since it reads
@@ -255,6 +260,40 @@ pub fn success(_theme: &Theme) -> text::Style {
 pub fn accent(_theme: &Theme) -> text::Style {
     text::Style {
         color: Some(ACCENT),
+    }
+}
+
+/// Rounded corners for every `text_input` (API Token, City, State/Province,
+/// Country) -- otherwise identical to iced's own `text_input::default`.
+/// Uses fully-qualified paths rather than importing `iced::widget::text_input`
+/// since that name is reused for this function itself.
+pub fn text_input(
+    theme: &Theme,
+    status: iced::widget::text_input::Status,
+) -> iced::widget::text_input::Style {
+    let default = iced::widget::text_input::default(theme, status);
+    iced::widget::text_input::Style {
+        border: Border {
+            radius: FIELD_RADIUS.into(),
+            ..default.border
+        },
+        ..default
+    }
+}
+
+/// Rounded corners for the Provider `pick_list`, matching `text_input`'s so
+/// every field in the form reads as the same rounded style.
+pub fn pick_list(
+    theme: &Theme,
+    status: iced::widget::pick_list::Status,
+) -> iced::widget::pick_list::Style {
+    let default = iced::widget::pick_list::default(theme, status);
+    iced::widget::pick_list::Style {
+        border: Border {
+            radius: FIELD_RADIUS.into(),
+            ..default.border
+        },
+        ..default
     }
 }
 

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -168,6 +168,36 @@ pub fn secondary_button(theme: &Theme, status: button::Status) -> button::Style 
     }
 }
 
+/// An accent-outlined button for secondary actions that still need to stand
+/// out against a `day_card` background -- unlike `secondary_button`'s
+/// neutral, theme-derived border (which reads as barely-there against the
+/// card's own near-identical gray in both light and dark mode), this uses
+/// the fixed `ACCENT` color for both border and text, matching the section
+/// headers so it stays legible regardless of theme.
+pub fn accent_button(theme: &Theme, status: button::Status) -> button::Style {
+    let palette = theme.extended_palette();
+
+    let (border_color, text_color) = match status {
+        button::Status::Hovered | button::Status::Pressed => (ACCENT_STRONG, ACCENT_STRONG),
+        button::Status::Active => (ACCENT, ACCENT),
+        button::Status::Disabled => (
+            palette.background.weak.color,
+            palette.background.strong.color,
+        ),
+    };
+
+    button::Style {
+        background: None,
+        text_color,
+        border: Border {
+            color: border_color,
+            width: 1.5,
+            radius: 8.0.into(),
+        },
+        ..button::Style::default()
+    }
+}
+
 /// A borderless, backgroundless button for inline "links" (e.g. the
 /// homepage URL in the About window) -- just accent-colored text that
 /// darkens slightly on hover, no button chrome.
@@ -209,6 +239,16 @@ pub fn default_text(_theme: &Theme) -> text::Style {
 pub fn danger(theme: &Theme) -> text::Style {
     text::Style {
         color: Some(theme.extended_palette().danger.base.color),
+    }
+}
+
+/// Success text (e.g. a passed connection test) -- iced's `Theme` has no
+/// built-in success palette to derive from (unlike `danger`), so this reuses
+/// `STAT_WIND`'s green as a fixed color that reads as "success" without
+/// clashing with the stat chips it's borrowed from.
+pub fn success(_theme: &Theme) -> text::Style {
+    text::Style {
+        color: Some(STAT_WIND),
     }
 }
 


### PR DESCRIPTION
## Summary
- Right now the only way to find out whether a provider/token/location combination actually works is to hit Save and watch the main panel, disconnected from the field just typed into.
- Adds `preferences::Message::TestConnectionRequested`/`Message::ConnectionTested`, `State::is_testing_connection`/`connection_test_result`, mirroring the existing `is_detecting_location`/`location_detection_error` pattern from location detection.
- New "Test connection" button under the API Token field, with an inline "✓ Connected" / "✗ <error>" status row.
- `app::update` builds a provider from the *currently-typed* provider/token/location (not the saved config) and fires a single `get_weather()` call. Purely informational — never blocks Save.
- Adds a `style::success` text style (iced's `Theme` has no built-in success palette, unlike `danger`) reusing `STAT_WIND`'s green.

Closes #43

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manually launched the app and confirmed the main window renders correctly