### PR TITLE
Make the auto-refresh interval user-configurable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ accumulating here.
 
 **Interface**
 
+- The auto-refresh interval is now user-configurable in Preferences (presets: 30s / 1m / 5m / 15m / 30m). To protect Google Maps Platform rate limits, a 15-minute floor is strictly enforced when using the Google Weather provider. (#44)
 - Preferences now has a "Verify API" button next to the API Token field:
   fires a single live request against the currently-typed
   provider/token/location (not the saved config) and shows an inline

--- a/docs/GOOGLE_WEATHER_API.md
+++ b/docs/GOOGLE_WEATHER_API.md
@@ -187,11 +187,12 @@ would need its own mapping since the day/night split has no equivalent in
   after a free tier of 10,000 calls/month.
 - Optional bundled subscription plans exist (Starter/Essentials/Pro,
   $100–$1,200/month) covering combined Maps Platform SKU usage, but pay-as-you-go
-  is the relevant model for a single desktop app polling one endpoint on a
-  30s `Tick` subscription — worth sanity-checking the free-tier math against
-  `src/app.rs`'s refresh interval before wiring this in for real
-  (30s polling × 2 endpoints ≈ 5,760 calls/day, well over the 10k/month free
-  cap on its own for a single always-open instance).
+  is the relevant model for a single desktop app.
+- The auto-refresh interval is user-configurable (defaults to 15 minutes for Google Weather,
+  with a hardcoded floor of 15 minutes enforced in preferences validation and subscription tick setup).
+  At 15 minutes, a single always-running instance generates 3 billable calls per refresh (current conditions + 2 forecast pages),
+  totaling ~8,640 calls/month, which stays safely within the 10,000 free monthly calls. Lowering the refresh interval below
+  15 minutes is disallowed for Google Weather to protect the free tier budget.
 
 ## What's not covered by the current mock
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -658,9 +658,19 @@ pub fn view(state: &AppState, window_id: window::Id) -> Element<'_, Message> {
 }
 
 pub fn subscription(state: &AppState) -> Subscription<Message> {
-    let refresh_interval = match state.config.weather_provider {
-        WeatherApiProvider::GoogleWeather => GOOGLE_WEATHER_REFRESH_INTERVAL,
-        WeatherApiProvider::OpenWeather => AUTO_REFRESH_INTERVAL,
+    let refresh_interval = match state.config.refresh_interval_secs {
+        Some(secs) => {
+            let duration = Duration::from_secs(secs);
+            if state.config.weather_provider == WeatherApiProvider::GoogleWeather {
+                duration.max(GOOGLE_WEATHER_REFRESH_INTERVAL)
+            } else {
+                duration
+            }
+        }
+        None => match state.config.weather_provider {
+            WeatherApiProvider::GoogleWeather => GOOGLE_WEATHER_REFRESH_INTERVAL,
+            WeatherApiProvider::OpenWeather => AUTO_REFRESH_INTERVAL,
+        },
     };
     Subscription::batch([
         iced::time::every(refresh_interval).map(Message::Tick),

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,11 @@ pub struct AppConfig {
     /// so toggling this doesn't trigger a re-fetch.
     #[serde(default)]
     pub use_fahrenheit: bool,
+    /// The user-configured auto-refresh interval in seconds.
+    /// `#[serde(default)]` ensures missing values default to None, retaining
+    /// default per-provider rates.
+    #[serde(default)]
+    pub refresh_interval_secs: Option<u64>,
     /// Present only to read config files saved by older versions of this
     /// app, which stored the API token base64-"encoded" (not encrypted)
     /// directly here. `#[serde(skip_serializing)]` means this is never
@@ -101,6 +106,7 @@ impl Default for AppConfig {
             location: LocationConfig::default(),
             dark_mode: false,
             use_fahrenheit: false,
+            refresh_interval_secs: None,
             legacy_api_token_encoded: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,69 @@ mod tests {
             state: "TS".to_string(),
             country: "TC".to_string(),
         };
+        config.refresh_interval_secs = Some(900);
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("GoogleWeather"));
         assert!(json.contains("Test City"));
+        assert!(json.contains("refresh_interval_secs"));
+        assert!(json.contains("900"));
         assert!(!json.contains("api_token"));
 
         let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.location.city, "Test City");
+        assert_eq!(deserialized.refresh_interval_secs, Some(900));
+
+        // Test migration-safe default where refresh_interval_secs is missing.
+        let missing_interval_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Peoria","state":"IL","country":"US"},"dark_mode":false,"use_fahrenheit":false}"#;
+        let deserialized_default: AppConfig = serde_json::from_str(missing_interval_json).unwrap();
+        assert_eq!(deserialized_default.refresh_interval_secs, None);
+    }
+
+    /// Verifies that the refresh interval validation logic enforces the
+    /// Google Weather rate limits while allowing fast intervals for OpenWeather.
+    #[test]
+    fn test_refresh_interval_validation() {
+        use crate::ui::preferences::{RefreshIntervalPreset, State as PrefsState};
+
+        let mut config = AppConfig::default();
+        config.weather_provider = WeatherApiProvider::OpenWeather;
+        config.refresh_interval_secs = Some(30);
+
+        // OpenWeather with 30 seconds is valid.
+        let mut prefs_state = PrefsState::from_config(&config);
+        // Set inputs to valid strings so other validators don't trigger.
+        prefs_state.token_input = "dummy_token".to_string();
+        prefs_state.city_input = "Peoria".to_string();
+        prefs_state.country_input = "US".to_string();
+
+        let errors = prefs_state.validation_errors();
+        assert!(
+            errors.is_empty(),
+            "OpenWeather with 30s should be valid: {:?}",
+            errors
+        );
+
+        // Switching provider to Google Weather with 30s preset is invalid.
+        prefs_state.provider = WeatherApiProvider::GoogleWeather;
+        prefs_state.refresh_interval = RefreshIntervalPreset::ThirtySeconds;
+        let errors = prefs_state.validation_errors();
+        assert!(
+            !errors.is_empty(),
+            "Google Weather with 30s should be invalid"
+        );
+        assert!(errors.iter().any(|e| {
+            e.contains("Google Weather requires a refresh interval of at least 15 minutes")
+        }));
+
+        // Google Weather with 15 minutes is valid.
+        prefs_state.refresh_interval = RefreshIntervalPreset::FifteenMinutes;
+        let errors = prefs_state.validation_errors();
+        assert!(
+            errors.is_empty(),
+            "Google Weather with 15m should be valid: {:?}",
+            errors
+        );
     }
 
     /// Verifies that a config file saved by an older version of this app

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -23,6 +23,72 @@ const PROVIDERS: [WeatherApiProvider; 2] = [
     WeatherApiProvider::GoogleWeather,
 ];
 
+/// Presets for the auto-refresh polling interval, offered as a pick list
+/// to prevent accidental rates-quota violations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshIntervalPreset {
+    ThirtySeconds,
+    OneMinute,
+    FiveMinutes,
+    FifteenMinutes,
+    ThirtyMinutes,
+}
+
+impl RefreshIntervalPreset {
+    pub const ALL: [Self; 5] = [
+        Self::ThirtySeconds,
+        Self::OneMinute,
+        Self::FiveMinutes,
+        Self::FifteenMinutes,
+        Self::ThirtyMinutes,
+    ];
+
+    pub fn to_secs(self) -> u64 {
+        match self {
+            Self::ThirtySeconds => 30,
+            Self::OneMinute => 60,
+            Self::FiveMinutes => 5 * 60,
+            Self::FifteenMinutes => 15 * 60,
+            Self::ThirtyMinutes => 30 * 60,
+        }
+    }
+
+    pub fn from_secs(secs: u64) -> Self {
+        match secs {
+            30 => Self::ThirtySeconds,
+            60 => Self::OneMinute,
+            300 => Self::FiveMinutes,
+            900 => Self::FifteenMinutes,
+            1800 => Self::ThirtyMinutes,
+            _ => {
+                if secs <= 30 {
+                    Self::ThirtySeconds
+                } else if secs <= 60 {
+                    Self::OneMinute
+                } else if secs <= 300 {
+                    Self::FiveMinutes
+                } else if secs <= 900 {
+                    Self::FifteenMinutes
+                } else {
+                    Self::ThirtyMinutes
+                }
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for RefreshIntervalPreset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ThirtySeconds => write!(f, "30 seconds"),
+            Self::OneMinute => write!(f, "1 minute"),
+            Self::FiveMinutes => write!(f, "5 minutes"),
+            Self::FifteenMinutes => write!(f, "15 minutes"),
+            Self::ThirtyMinutes => write!(f, "30 minutes"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct State {
     pub provider: WeatherApiProvider,
@@ -32,6 +98,7 @@ pub struct State {
     pub country_input: String,
     pub dark_mode: bool,
     pub use_fahrenheit: bool,
+    pub refresh_interval: RefreshIntervalPreset,
     /// Set by `app::boot` when this window was opened automatically because
     /// no config file existed yet (see `ConfigManager::config_exists`).
     /// Purely cosmetic -- swaps in a welcome banner (`view`) and the
@@ -80,6 +147,13 @@ impl State {
             country_input: config.location.country.clone(),
             dark_mode: config.dark_mode,
             use_fahrenheit: config.use_fahrenheit,
+            refresh_interval: config
+                .refresh_interval_secs
+                .map(RefreshIntervalPreset::from_secs)
+                .unwrap_or_else(|| match config.weather_provider {
+                    WeatherApiProvider::GoogleWeather => RefreshIntervalPreset::FifteenMinutes,
+                    WeatherApiProvider::OpenWeather => RefreshIntervalPreset::ThirtySeconds,
+                }),
             is_first_run: false,
             is_detecting_location: false,
             location_detection_error: None,
@@ -101,6 +175,7 @@ impl State {
         config.location.country = self.country_input.clone();
         config.dark_mode = self.dark_mode;
         config.use_fahrenheit = self.use_fahrenheit;
+        config.refresh_interval_secs = Some(self.refresh_interval.to_secs());
         Ok(())
     }
 
@@ -121,6 +196,14 @@ impl State {
         if self.token_input.trim().is_empty() {
             errors.push(format!("API Token is required for {}.", self.provider));
         }
+        // Validate Google Weather refresh interval constraint
+        if self.provider == WeatherApiProvider::GoogleWeather
+            && self.refresh_interval.to_secs() < 15 * 60
+        {
+            errors.push(
+                "Google Weather requires a refresh interval of at least 15 minutes.".to_string(),
+            );
+        }
 
         errors
     }
@@ -135,6 +218,7 @@ pub enum Message {
     CountryChanged(String),
     DarkModeToggled(bool),
     UnitsToggled(bool),
+    RefreshIntervalSelected(RefreshIntervalPreset),
     /// The "Get an API key" link -- intercepted by the parent (see
     /// `src/app.rs`) and turned into `Message::OpenUrl`, since opening a
     /// browser is an app-level concern, not something this module does
@@ -170,6 +254,7 @@ pub fn update(state: &mut State, message: Message) {
         Message::CountryChanged(value) => state.country_input = value,
         Message::DarkModeToggled(value) => state.dark_mode = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
+        Message::RefreshIntervalSelected(value) => state.refresh_interval = value,
         Message::OpenUrl(_)
         | Message::DetectLocationRequested
         | Message::TestConnectionRequested
@@ -274,7 +359,7 @@ pub fn view(state: &State) -> Element<'_, Message> {
     let location_section = section("\u{2302} Home", location_column.into());
 
     let appearance_section = section(
-        "\u{263e} Appearance",
+        "\u{263e} Appearance & Refresh",
         column![
             toggler(state.dark_mode)
                 .label("Dark mode")
@@ -282,6 +367,16 @@ pub fn view(state: &State) -> Element<'_, Message> {
             toggler(state.use_fahrenheit)
                 .label("Use Fahrenheit (\u{b0}F)")
                 .on_toggle(Message::UnitsToggled),
+            labeled_row(
+                "Refresh Interval:",
+                pick_list(
+                    &RefreshIntervalPreset::ALL[..],
+                    Some(state.refresh_interval),
+                    Message::RefreshIntervalSelected
+                )
+                .style(style::pick_list)
+                .into()
+            ),
         ]
         .spacing(12)
         .into(),


### PR DESCRIPTION
## Summary
- Add `refresh_interval_secs: Option<u64>` to `AppConfig`, `#[serde(default)]` so existing config files still load with the old hardcoded per-provider defaults.
- Add a preset `pick_list` (30s / 1m / 5m / 15m / 30m) to the Preferences "Appearance & Refresh" section instead of free-text seconds, with a validated 15-minute floor enforced for Google Weather.
- `subscription()` now uses the configured interval when present, with a runtime `.max(GOOGLE_WEATHER_REFRESH_INTERVAL)` floor as defense-in-depth.
- Update `docs/GOOGLE_WEATHER_API.md`'s call-budget math to reflect the new user-adjustable interval and enforced floor.

Closes #44

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all` (28 + 19 tests pass, including new `test_refresh_interval_validation` and migration-safe default coverage)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`