### PR TITLE
Add weather alerts (Google Weather publicAlerts endpoint)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ accumulating here.
 
 **Interface**
 
+- Active weather alerts (severe thunderstorm, flood, etc.) now surface as a banner above the current-conditions card when using the Google Weather provider, fetched via `publicAlerts:lookup` on the same refresh cycle as current conditions. OpenWeatherMap has no free-tier alerts equivalent, so it always shows none. (#45)
 - The auto-refresh interval is now user-configurable in Preferences (presets: 30s / 1m / 5m / 15m / 30m). To protect Google Maps Platform rate limits, a 15-minute floor is strictly enforced when using the Google Weather provider. (#44)
 - Preferences now has a "Verify API" button next to the API Token field:
   fires a single live request against the currently-typed

--- a/docs/GOOGLE_WEATHER_API.md
+++ b/docs/GOOGLE_WEATHER_API.md
@@ -190,9 +190,11 @@ would need its own mapping since the day/night split has no equivalent in
   is the relevant model for a single desktop app.
 - The auto-refresh interval is user-configurable (defaults to 15 minutes for Google Weather,
   with a hardcoded floor of 15 minutes enforced in preferences validation and subscription tick setup).
-  At 15 minutes, a single always-running instance generates 3 billable calls per refresh (current conditions + 2 forecast pages),
-  totaling ~8,640 calls/month, which stays safely within the 10,000 free monthly calls. Lowering the refresh interval below
-  15 minutes is disallowed for Google Weather to protect the free tier budget.
+  At 15 minutes, a single always-running instance generates 4 billable calls per refresh (current
+  conditions + 2 forecast pages + `publicAlerts:lookup`), totaling ~11,520 calls/month, which
+  exceeds the 10,000 free monthly calls on its own for an always-open instance -- worth revisiting
+  the default/floor or the alerts fetch cadence before this ships broadly. Lowering the refresh
+  interval below 15 minutes is disallowed for Google Weather to protect the free tier budget.
 
 ## What's not covered by the current mock
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use crate::ui::temperature::{
     pressure_to_display, pressure_unit, speed_to_display, speed_unit, unit_symbol,
 };
 use crate::ui::{about, main_screen, preferences, transition};
+use crate::weather_api::alerts::WeatherAlert;
 use crate::weather_api::forecast::ForecastResponse;
 use crate::weather_api::openweather_api::ApiResponse;
 use crate::weather_api::weather_provider::WeatherProviderFactory;
@@ -110,9 +111,10 @@ impl ForecastStatus {
 /// shared-closure problem the GTK version solved with a mutex doesn't exist here.
 pub struct AppState {
     pub config: AppConfig,
-    config_manager: ConfigManager,
+    pub config_manager: ConfigManager,
     pub weather: WeatherStatus,
     pub forecast: ForecastStatus,
+    pub alerts: Vec<WeatherAlert>,
     /// When `weather` last transitioned to `Loaded`, for the "Updated Xs ago"
     /// label. `main_screen` re-renders often enough (via `AnimationTick`,
     /// already needed for the animated icons) that this stays fresh without
@@ -145,6 +147,7 @@ pub enum Message {
     Tick(#[allow(dead_code)] std::time::Instant),
     WeatherFetched(Result<ApiResponse, String>),
     ForecastFetched(Result<ForecastResponse, String>),
+    AlertsFetched(Result<Vec<WeatherAlert>, String>),
 
     OpenPreferences,
     OpenAbout,
@@ -223,6 +226,25 @@ fn fetch_forecast_task(config: &AppConfig) -> Task<Message> {
                 .map_err(|e| format!("{:?}", e))
         },
         Message::ForecastFetched,
+    )
+}
+
+/// Builds a `Task` that fetches active weather alerts.
+fn fetch_alerts_task(config: &AppConfig) -> Task<Message> {
+    let provider_type = config.weather_provider.clone();
+    let location = config.location.clone();
+    let config = config.clone();
+
+    Task::perform(
+        async move {
+            let token = config.get_api_token().ok();
+            let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+            provider
+                .get_alerts(&location)
+                .await
+                .map_err(|e| format!("{:?}", e))
+        },
+        Message::AlertsFetched,
     )
 }
 
@@ -348,13 +370,18 @@ pub fn boot() -> (AppState, Task<Message>) {
         (
             None,
             None,
-            Task::batch([fetch_weather_task(&config), fetch_forecast_task(&config)]),
+            Task::batch([
+                fetch_weather_task(&config),
+                fetch_forecast_task(&config),
+                fetch_alerts_task(&config),
+            ]),
         )
     };
 
     let state = AppState {
         weather: WeatherStatus::Loading,
         forecast: ForecastStatus::Loading,
+        alerts: vec![],
         last_updated: None,
         value_tracker: transition::ValueTracker::default(),
         selected_forecast_day: None,
@@ -391,6 +418,7 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
             Task::batch([
                 fetch_weather_task(&state.config),
                 fetch_forecast_task(&state.config),
+                fetch_alerts_task(&state.config),
             ])
         }
         Message::WeatherFetched(Ok(response)) => {
@@ -449,6 +477,15 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                     ForecastStatus::Error
                 }
             };
+            Task::none()
+        }
+        Message::AlertsFetched(Ok(alerts)) => {
+            state.alerts = alerts;
+            Task::none()
+        }
+        Message::AlertsFetched(Err(error)) => {
+            log::warn!("Alerts fetch failed: {error}");
+            // We retain existing alerts on failure, or could clear them. Keeping them for now.
             Task::none()
         }
         Message::OpenPreferences => {

--- a/src/ui/main_screen.rs
+++ b/src/ui/main_screen.rs
@@ -7,7 +7,7 @@
 use std::time::Instant;
 
 use iced::widget::{button, column, container, row, scrollable, space, text, tooltip};
-use iced::{font, Alignment, Color, Element, Font, Length, Theme};
+use iced::{Alignment, Color, Element, Font, Length, Theme, font};
 
 use crate::app::{AppState, ForecastStatus, Message, WeatherStatus};
 use crate::config::WeatherApiProvider;
@@ -180,44 +180,64 @@ fn alerts_view(alerts: &[WeatherAlert]) -> Element<'_, Message> {
     if alerts.is_empty() {
         return iced::widget::Space::new().into();
     }
-    
+
     let mut layout = column![].spacing(8).width(Length::Fill);
-    
+
     for alert in alerts {
-        let (icon, _) = match alert.severity {
-            AlertSeverity::Extreme | AlertSeverity::Severe => ("\u{26A0}", ()), // Warning sign
-            _ => ("\u{24D8}", ()), // Info sign
+        let is_severe = matches!(
+            alert.severity,
+            AlertSeverity::Extreme | AlertSeverity::Severe
+        );
+        let icon = if is_severe { "\u{26A0}" } else { "\u{24D8}" };
+        let text_style = if is_severe {
+            style::danger
+        } else {
+            style::warning
         };
 
-        let alert_banner = container(
+        let mut banner_content = column![
             row![
-                text(icon).size(16).style(style::danger),
-                text(&alert.title).size(14).font(BOLD).style(style::danger),
+                text(icon).size(16).style(text_style),
+                text(&alert.title).size(14).font(BOLD).style(text_style),
             ]
             .spacing(8)
             .align_y(Alignment::Center),
-        )
-        .padding(12)
-        .width(Length::Fill)
-        .style(move |theme: &Theme| {
-            let palette = theme.extended_palette();
-            container::Style {
-                background: Some(iced::Background::Color(Color {
-                    a: 0.1,
-                    ..palette.danger.base.color
-                })),
-                border: iced::Border {
-                    color: palette.danger.base.color,
-                    width: 1.0,
-                    radius: 8.0.into(),
-                },
-                ..container::Style::default()
+        ]
+        .spacing(6);
+
+        if !alert.safety_recommendations.is_empty() {
+            for recommendation in &alert.safety_recommendations {
+                banner_content =
+                    banner_content.push(text(recommendation).size(12).style(style::muted));
             }
-        });
-        
+        }
+
+        let alert_banner = container(banner_content)
+            .padding(12)
+            .width(Length::Fill)
+            .style(move |theme: &Theme| {
+                let accent_color = if is_severe {
+                    style::danger(theme).color.unwrap_or(Color::BLACK)
+                } else {
+                    style::warning(theme).color.unwrap_or(Color::BLACK)
+                };
+                container::Style {
+                    background: Some(iced::Background::Color(Color {
+                        a: 0.1,
+                        ..accent_color
+                    })),
+                    border: iced::Border {
+                        color: accent_color,
+                        width: 1.0,
+                        radius: 8.0.into(),
+                    },
+                    ..container::Style::default()
+                }
+            });
+
         layout = layout.push(alert_banner);
     }
-    
+
     layout.into()
 }
 

--- a/src/ui/main_screen.rs
+++ b/src/ui/main_screen.rs
@@ -7,7 +7,7 @@
 use std::time::Instant;
 
 use iced::widget::{button, column, container, row, scrollable, space, text, tooltip};
-use iced::{Alignment, Color, Element, Font, Length, font};
+use iced::{font, Alignment, Color, Element, Font, Length, Theme};
 
 use crate::app::{AppState, ForecastStatus, Message, WeatherStatus};
 use crate::config::WeatherApiProvider;
@@ -17,6 +17,7 @@ use crate::ui::temperature::{
 };
 use crate::ui::transition::ValueTracker;
 use crate::ui::{forecast_row, icons, skeleton, style};
+use crate::weather_api::alerts::{AlertSeverity, WeatherAlert};
 use crate::weather_api::forecast::ForecastDay;
 use crate::weather_api::openweather_api::{ApiResponse, Weather, get_weather_symbol};
 
@@ -87,6 +88,7 @@ pub fn view(state: &AppState) -> Element<'_, Message> {
         };
 
         let mut card = column![
+            alerts_view(&state.alerts),
             row![
                 hero_view(
                     weather_data,
@@ -172,6 +174,51 @@ pub fn view(state: &AppState) -> Element<'_, Message> {
         provider_ribbon(&state.config.weather_provider),
     ]
     .into()
+}
+
+fn alerts_view(alerts: &[WeatherAlert]) -> Element<'_, Message> {
+    if alerts.is_empty() {
+        return iced::widget::Space::new().into();
+    }
+    
+    let mut layout = column![].spacing(8).width(Length::Fill);
+    
+    for alert in alerts {
+        let (icon, _) = match alert.severity {
+            AlertSeverity::Extreme | AlertSeverity::Severe => ("\u{26A0}", ()), // Warning sign
+            _ => ("\u{24D8}", ()), // Info sign
+        };
+
+        let alert_banner = container(
+            row![
+                text(icon).size(16).style(style::danger),
+                text(&alert.title).size(14).font(BOLD).style(style::danger),
+            ]
+            .spacing(8)
+            .align_y(Alignment::Center),
+        )
+        .padding(12)
+        .width(Length::Fill)
+        .style(move |theme: &Theme| {
+            let palette = theme.extended_palette();
+            container::Style {
+                background: Some(iced::Background::Color(Color {
+                    a: 0.1,
+                    ..palette.danger.base.color
+                })),
+                border: iced::Border {
+                    color: palette.danger.base.color,
+                    width: 1.0,
+                    radius: 8.0.into(),
+                },
+                ..container::Style::default()
+            }
+        });
+        
+        layout = layout.push(alert_banner);
+    }
+    
+    layout.into()
 }
 
 /// A thin footer strip naming whichever provider is currently powering the

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -263,6 +263,15 @@ pub fn accent(_theme: &Theme) -> text::Style {
     }
 }
 
+/// Warning text (e.g. a Minor/Moderate weather alert) -- reuses
+/// `STAT_SUNRISE`'s amber for a "pay attention" tone one notch below
+/// `danger`'s red, since iced's `Theme` has no built-in warning palette.
+pub fn warning(_theme: &Theme) -> text::Style {
+    text::Style {
+        color: Some(STAT_SUNRISE),
+    }
+}
+
 /// Rounded corners for every `text_input` (API Token, City, State/Province,
 /// Country) -- otherwise identical to iced's own `text_input::default`.
 /// Uses fully-qualified paths rather than importing `iced::widget::text_input`

--- a/src/weather_api/alerts.rs
+++ b/src/weather_api/alerts.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+/// Severity of a weather alert.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum AlertSeverity {
+    UnknownSeverity,
+    Minor,
+    Moderate,
+    Severe,
+    Extreme,
+}
+
+impl Default for AlertSeverity {
+    fn default() -> Self {
+        Self::UnknownSeverity
+    }
+}
+
+/// A weather alert (e.g., severe thunderstorm warning) for a specific location.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WeatherAlert {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub event_type: String,
+    pub severity: AlertSeverity,
+    /// Unix timestamp for when the alert becomes active.
+    pub start_time: i64,
+    /// Unix timestamp for when the alert expires.
+    pub end_time: i64,
+    pub urgency: String,
+    pub certainty: String,
+    pub instruction: Vec<String>,
+}

--- a/src/weather_api/alerts.rs
+++ b/src/weather_api/alerts.rs
@@ -1,20 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 /// Severity of a weather alert.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum AlertSeverity {
+    #[default]
     UnknownSeverity,
     Minor,
     Moderate,
     Severe,
     Extreme,
-}
-
-impl Default for AlertSeverity {
-    fn default() -> Self {
-        Self::UnknownSeverity
-    }
 }
 
 /// A weather alert (e.g., severe thunderstorm warning) for a specific location.
@@ -31,5 +26,7 @@ pub struct WeatherAlert {
     pub end_time: i64,
     pub urgency: String,
     pub certainty: String,
+    pub area_name: String,
     pub instruction: Vec<String>,
+    pub safety_recommendations: Vec<String>,
 }

--- a/src/weather_api/google_weather_api.rs
+++ b/src/weather_api/google_weather_api.rs
@@ -645,7 +645,9 @@ impl WeatherProvider for GoogleWeatherProvider {
                     end_time,
                     urgency: g_alert.urgency,
                     certainty: g_alert.certainty,
+                    area_name: g_alert.area_name,
                     instruction: g_alert.instruction,
+                    safety_recommendations: g_alert.safety_recommendations,
                 }
             })
             .collect();
@@ -838,6 +840,8 @@ mod tests {
         assert_eq!(alert.alert_title, "Severe Thunderstorm Warning");
         assert_eq!(alert.severity, "SEVERE");
         assert_eq!(alert.start_time, "2026-07-04T11:00:00Z");
+        assert_eq!(alert.area_name, "Peoria County");
         assert_eq!(alert.instruction[0], "Take cover immediately.");
+        assert_eq!(alert.safety_recommendations[0], "Stay indoors.");
     }
 }

--- a/src/weather_api/google_weather_api.rs
+++ b/src/weather_api/google_weather_api.rs
@@ -26,6 +26,7 @@
 //! that zone id at that instant.
 
 use crate::config::LocationConfig;
+use crate::weather_api::alerts::{AlertSeverity, WeatherAlert};
 use crate::weather_api::forecast::{ForecastDay, ForecastResponse};
 use crate::weather_api::openweather_api::{
     ApiError, ApiResponse, Main, Sys, Weather, Wind, get_weather_symbol,
@@ -292,6 +293,44 @@ struct ForecastDaysResponse {
     time_zone: GTimeZone,
 }
 
+// --- Google Weather Alerts types ----------------------------------------
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GAlert {
+    #[serde(default)]
+    alert_id: String,
+    #[serde(default)]
+    alert_title: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    event_type: String,
+    #[serde(default)]
+    severity: String,
+    #[serde(default)]
+    certainty: String,
+    #[serde(default)]
+    urgency: String,
+    #[serde(default)]
+    start_time: String,
+    #[serde(default)]
+    expiration_time: String,
+    #[serde(default)]
+    area_name: String,
+    #[serde(default)]
+    instruction: Vec<String>,
+    #[serde(default)]
+    safety_recommendations: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct PublicAlertsResponse {
+    #[serde(default)]
+    public_alerts: Vec<GAlert>,
+}
+
 // --- Unit conversions -----------------------------------------------------
 // Google's METRIC unit system (requested explicitly below) returns wind
 // speed in km/h and visibility in km; the shared `Wind`/visibility fields
@@ -440,6 +479,34 @@ async fn fetch_forecast_days(
     })
 }
 
+async fn fetch_public_alerts(
+    client: &reqwest::Client,
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+) -> Result<PublicAlertsResponse, ApiError> {
+    let response = client
+        .get(format!("{WEATHER_API_BASE}/publicAlerts:lookup"))
+        .query(&[
+            ("key", api_key.to_string()),
+            ("location.latitude", lat.to_string()),
+            ("location.longitude", lon.to_string()),
+        ])
+        .send()
+        .await
+        .map_err(ApiError::RequestFailed)?;
+
+    if !response.status().is_success() {
+        log::error!("Google publicAlerts request failed: {}", response.status());
+        return Err(ApiError::CityNotFound); // Keep uniform error mapping for now
+    }
+
+    response.json::<PublicAlertsResponse>().await.map_err(|e| {
+        log::error!("Failed to parse Google publicAlerts response: {e}");
+        ApiError::InvalidResponse
+    })
+}
+
 fn map_forecast_day(item: &ForecastDayItem) -> ForecastDay {
     let day = &item.daytime_forecast;
     ForecastDay {
@@ -547,6 +614,43 @@ impl WeatherProvider for GoogleWeatherProvider {
                 .map(map_forecast_day)
                 .collect(),
         })
+    }
+
+    async fn get_alerts(&self, location: &LocationConfig) -> Result<Vec<WeatherAlert>, ApiError> {
+        let (lat, lon) = geocode(&self.client, location).await?;
+        let alerts_response = fetch_public_alerts(&self.client, &self.api_key, lat, lon).await?;
+
+        let alerts = alerts_response
+            .public_alerts
+            .into_iter()
+            .map(|g_alert| {
+                let severity = match g_alert.severity.as_str() {
+                    "EXTREME" => AlertSeverity::Extreme,
+                    "SEVERE" => AlertSeverity::Severe,
+                    "MODERATE" => AlertSeverity::Moderate,
+                    "MINOR" => AlertSeverity::Minor,
+                    _ => AlertSeverity::UnknownSeverity,
+                };
+
+                let (start_time, _) = resolve_epoch_and_offset(&g_alert.start_time, "UTC");
+                let (end_time, _) = resolve_epoch_and_offset(&g_alert.expiration_time, "UTC");
+
+                WeatherAlert {
+                    id: g_alert.alert_id,
+                    title: g_alert.alert_title,
+                    description: g_alert.description,
+                    event_type: g_alert.event_type,
+                    severity,
+                    start_time,
+                    end_time,
+                    urgency: g_alert.urgency,
+                    certainty: g_alert.certainty,
+                    instruction: g_alert.instruction,
+                }
+            })
+            .collect();
+
+        Ok(alerts)
     }
 }
 
@@ -706,5 +810,34 @@ mod tests {
         let (epoch, offset) = resolve_epoch_and_offset("not-a-timestamp", "America/Chicago");
         assert_eq!(epoch, 0);
         assert_eq!(offset, 0);
+    }
+
+    #[test]
+    fn test_public_alerts_deserialize_and_map() {
+        let json = r#"{
+            "publicAlerts": [
+                {
+                    "alertId": "12345",
+                    "alertTitle": "Severe Thunderstorm Warning",
+                    "description": "A severe thunderstorm warning is in effect.",
+                    "eventType": "SEVERE_THUNDERSTORM",
+                    "severity": "SEVERE",
+                    "certainty": "OBSERVED",
+                    "urgency": "IMMEDIATE",
+                    "startTime": "2026-07-04T11:00:00Z",
+                    "expirationTime": "2026-07-04T12:00:00Z",
+                    "areaName": "Peoria County",
+                    "instruction": ["Take cover immediately."],
+                    "safetyRecommendations": ["Stay indoors."]
+                }
+            ]
+        }"#;
+        let parsed: PublicAlertsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.public_alerts.len(), 1);
+        let alert = &parsed.public_alerts[0];
+        assert_eq!(alert.alert_title, "Severe Thunderstorm Warning");
+        assert_eq!(alert.severity, "SEVERE");
+        assert_eq!(alert.start_time, "2026-07-04T11:00:00Z");
+        assert_eq!(alert.instruction[0], "Take cover immediately.");
     }
 }

--- a/src/weather_api/mod.rs
+++ b/src/weather_api/mod.rs
@@ -9,6 +9,7 @@
 //! - `openweather_api`: Contains the implementation for the real OpenWeatherMap API.
 //! - `google_weather_api`: Contains a mock implementation for a "Google Weather" API, used for testing and demonstration.
 //! - `forecast`: Data model and aggregation logic for multi-day forecasts.
+pub mod alerts;
 pub mod forecast;
 pub mod google_weather_api;
 pub mod openweather_api;

--- a/src/weather_api/weather_provider.rs
+++ b/src/weather_api/weather_provider.rs
@@ -14,6 +14,7 @@
 //!   based on the application's configuration.
 
 use crate::config::{LocationConfig, WeatherApiProvider};
+use crate::weather_api::alerts::WeatherAlert;
 use crate::weather_api::forecast::ForecastResponse;
 use crate::weather_api::openweather_api::{ApiError, ApiResponse, Location};
 use async_trait::async_trait;
@@ -40,6 +41,14 @@ pub trait WeatherProvider {
     /// # Errors
     /// Returns an `ApiError` if the data cannot be fetched.
     async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError>;
+
+    /// Fetches active weather alerts for a given location.
+    ///
+    /// # Errors
+    /// Returns an `ApiError` if the data cannot be fetched.
+    async fn get_alerts(&self, _location: &LocationConfig) -> Result<Vec<WeatherAlert>, ApiError> {
+        Ok(vec![])
+    }
 }
 
 /// A factory for creating weather providers.


### PR DESCRIPTION
## Summary
- New `WeatherAlert`/`AlertSeverity` types (`src/weather_api/alerts.rs`) and a `get_alerts` method on `WeatherProvider`, defaulting to `Ok(vec![])` so `OpenWeatherProvider` needs no changes (no free-tier alerts endpoint to call).
- `GoogleWeatherProvider::get_alerts` calls `publicAlerts:lookup` and maps the response, including `area_name` and `safety_recommendations`.
- Alerts are fetched on the same `Tick` cadence as current conditions/forecast (no separate timer).
- Main screen renders active alerts as a banner above the current-conditions card: red for Extreme/Severe, amber `style::warning` for Minor/Moderate, with `safety_recommendations` shown as sub-lines.
- Fixture-based unit test for `publicAlerts:lookup` response parsing (no live network in `cargo test`).

## Notes
- `docs/GOOGLE_WEATHER_API.md`'s call-budget math is updated: the new `publicAlerts:lookup` call brings a 15-minute-refresh instance to ~11,520 calls/month, which is *above* the 10,000/month free tier on its own for an always-open instance. This is flagged in the doc as a follow-up decision (raise the floor above 15 min, or move alerts to a slower cadence than current conditions) rather than resolved here.
- Manual/live verification against a real Google Weather API key is still outstanding, per the issue's scope checklist.

Closes #45

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [ ] Manual verification against a real Google Weather API key