### PR TITLE
Add a 'Launch at login' preference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17918dba7ecf78b9a14507ec9f984e7977d13fad87dc86d61038980a45d128cf"
+dependencies = [
+ "dirs",
+ "os_info",
+ "smappservice-rs",
+ "thiserror 2.0.18",
+ "windows-registry",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2976,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no_std_io2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,6 +3414,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,7 +3465,28 @@ dependencies = [
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -3440,6 +3511,16 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3470,6 +3551,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto-launch",
  "base64",
  "clap",
  "dirs",
@@ -3573,6 +3655,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4640,6 +4737,18 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-service-management",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -6271,7 +6380,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ open = "5.3.2"
 keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync-secret-service"] }
 jiff = "0.2.31"
 clap = { version = "4.6.1", features = ["derive"] }
+auto-launch = "0.6.0"
 
 [[bin]]
 name = "open-weather-wizard"

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,10 @@ pub struct AppConfig {
     /// so toggling this doesn't trigger a re-fetch.
     #[serde(default)]
     pub use_fahrenheit: bool,
+    /// Whether the app should automatically start when the user logs in.
+    /// `#[serde(default)]` so older config files default to `false`.
+    #[serde(default)]
+    pub launch_at_login: bool,
     /// The user-configured auto-refresh interval in seconds.
     /// `#[serde(default)]` ensures missing values default to None, retaining
     /// default per-provider rates.
@@ -106,6 +110,7 @@ impl Default for AppConfig {
             location: LocationConfig::default(),
             dark_mode: false,
             use_fahrenheit: false,
+            launch_at_login: false,
             refresh_interval_secs: None,
             legacy_api_token_encoded: None,
         }
@@ -161,6 +166,26 @@ impl AppConfig {
             Err(keyring::Error::NoEntry) => Ok(()),
             Err(e) => Err(format!("Failed to delete API token: {e}")),
         }
+    }
+
+    /// Applies the `launch_at_login` preference to the OS.
+    pub fn update_auto_launch(&self) -> Result<(), String> {
+        let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
+        
+        let auto = auto_launch::AutoLaunchBuilder::new()
+            .set_app_name("open-weather-wizard")
+            .set_app_path(&current_exe.to_string_lossy())
+            .set_macos_launch_mode(auto_launch::MacOSLaunchMode::LaunchAgent)
+            .build()
+            .map_err(|e| e.to_string())?;
+
+        if self.launch_at_login {
+            auto.enable().map_err(|e| e.to_string())?;
+        } else {
+            let _ = auto.disable();
+        }
+        
+        Ok(())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,7 +171,7 @@ impl AppConfig {
     /// Applies the `launch_at_login` preference to the OS.
     pub fn update_auto_launch(&self) -> Result<(), String> {
         let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
-        
+
         let auto = auto_launch::AutoLaunchBuilder::new()
             .set_app_name("open-weather-wizard")
             .set_app_path(&current_exe.to_string_lossy())
@@ -182,9 +182,9 @@ impl AppConfig {
         if self.launch_at_login {
             auto.enable().map_err(|e| e.to_string())?;
         } else {
-            let _ = auto.disable();
+            auto.disable().map_err(|e| e.to_string())?;
         }
-        
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,22 +74,27 @@ mod tests {
             country: "TC".to_string(),
         };
         config.refresh_interval_secs = Some(900);
+        config.launch_at_login = true;
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("GoogleWeather"));
         assert!(json.contains("Test City"));
         assert!(json.contains("refresh_interval_secs"));
         assert!(json.contains("900"));
+        assert!(json.contains("launch_at_login"));
         assert!(!json.contains("api_token"));
 
         let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.location.city, "Test City");
         assert_eq!(deserialized.refresh_interval_secs, Some(900));
+        assert!(deserialized.launch_at_login);
 
-        // Test migration-safe default where refresh_interval_secs is missing.
+        // Test migration-safe default where refresh_interval_secs and
+        // launch_at_login are missing.
         let missing_interval_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Peoria","state":"IL","country":"US"},"dark_mode":false,"use_fahrenheit":false}"#;
         let deserialized_default: AppConfig = serde_json::from_str(missing_interval_json).unwrap();
         assert_eq!(deserialized_default.refresh_interval_secs, None);
+        assert!(!deserialized_default.launch_at_login);
     }
 
     /// Verifies that the refresh interval validation logic enforces the

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -98,6 +98,7 @@ pub struct State {
     pub country_input: String,
     pub dark_mode: bool,
     pub use_fahrenheit: bool,
+    pub launch_at_login: bool,
     pub refresh_interval: RefreshIntervalPreset,
     /// Set by `app::boot` when this window was opened automatically because
     /// no config file existed yet (see `ConfigManager::config_exists`).
@@ -147,6 +148,7 @@ impl State {
             country_input: config.location.country.clone(),
             dark_mode: config.dark_mode,
             use_fahrenheit: config.use_fahrenheit,
+            launch_at_login: config.launch_at_login,
             refresh_interval: config
                 .refresh_interval_secs
                 .map(RefreshIntervalPreset::from_secs)
@@ -175,7 +177,9 @@ impl State {
         config.location.country = self.country_input.clone();
         config.dark_mode = self.dark_mode;
         config.use_fahrenheit = self.use_fahrenheit;
+        config.launch_at_login = self.launch_at_login;
         config.refresh_interval_secs = Some(self.refresh_interval.to_secs());
+        config.update_auto_launch().map_err(|e| format!("Failed to configure auto-launch: {}", e))?;
         Ok(())
     }
 
@@ -218,6 +222,7 @@ pub enum Message {
     CountryChanged(String),
     DarkModeToggled(bool),
     UnitsToggled(bool),
+    LaunchAtLoginToggled(bool),
     RefreshIntervalSelected(RefreshIntervalPreset),
     /// The "Get an API key" link -- intercepted by the parent (see
     /// `src/app.rs`) and turned into `Message::OpenUrl`, since opening a
@@ -254,6 +259,7 @@ pub fn update(state: &mut State, message: Message) {
         Message::CountryChanged(value) => state.country_input = value,
         Message::DarkModeToggled(value) => state.dark_mode = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
+        Message::LaunchAtLoginToggled(value) => state.launch_at_login = value,
         Message::RefreshIntervalSelected(value) => state.refresh_interval = value,
         Message::OpenUrl(_)
         | Message::DetectLocationRequested
@@ -367,6 +373,9 @@ pub fn view(state: &State) -> Element<'_, Message> {
             toggler(state.use_fahrenheit)
                 .label("Use Fahrenheit (\u{b0}F)")
                 .on_toggle(Message::UnitsToggled),
+            toggler(state.launch_at_login)
+                .label("Launch at login")
+                .on_toggle(Message::LaunchAtLoginToggled),
             labeled_row(
                 "Refresh Interval:",
                 pick_list(

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -164,9 +164,10 @@ impl State {
         }
     }
 
-    /// Writes the edited fields back into the shared `AppConfig`. Only
-    /// `set_api_token` (an OS keychain write) can actually fail -- everything
-    /// else here is an in-memory field assignment.
+    /// Writes the edited fields back into the shared `AppConfig`. Two steps
+    /// can fail: `set_api_token` (an OS keychain write) and
+    /// `update_auto_launch` (an OS-level login-item registration) --
+    /// everything else here is an in-memory field assignment.
     pub fn apply_to(&self, config: &mut AppConfig) -> Result<(), String> {
         config.weather_provider = self.provider.clone();
         if !self.token_input.is_empty() {
@@ -179,7 +180,9 @@ impl State {
         config.use_fahrenheit = self.use_fahrenheit;
         config.launch_at_login = self.launch_at_login;
         config.refresh_interval_secs = Some(self.refresh_interval.to_secs());
-        config.update_auto_launch().map_err(|e| format!("Failed to configure auto-launch: {}", e))?;
+        config
+            .update_auto_launch()
+            .map_err(|e| format!("Failed to configure auto-launch: {}", e))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Add the `auto-launch` crate (registry on Windows, Launch Agent on macOS, XDG Autostart/systemd on Linux).
- `AppConfig.launch_at_login: bool`, `#[serde(default)]`, migration-safe default `false`.
- Preferences toggle alongside Dark Mode / Use Fahrenheit; applied via `apply_to()` on Save only (discarded on Cancel, consistent with every other field here).
- `AppConfig::update_auto_launch()` enables/disables the OS login item; both `enable()` and `disable()` failures now surface to the user (verified `disable()` is idempotent across all three platform backends, so re-saving with the toggle already off is safe).

## Verification
- Manual: macOS (this environment).
- Windows/Linux: CI-compile-verified only (`windows-latest`/`ubuntu-latest`), same caveat as the geolocation work (#38/#5) — flagging per that precedent rather than claiming untested platforms work.

Closes #46

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all` (added `launch_at_login` roundtrip + migration-safe-default coverage to `test_config_serialization`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manual toggle verification on macOS
- [ ] Manual toggle verification on Windows/Linux