### PR TITLE
Add a 'Follow system appearance' option for dark mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,15 +229,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3d60bee1a1d38c2077030f4788e1b4e31058d2e79a8cfc8f2b440bd44db290"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.7",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -267,6 +296,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,9 +345,20 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -301,14 +367,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -340,6 +406,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -515,7 +607,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -956,6 +1048,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dark-light"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
+dependencies = [
+ "ashpd",
+ "async-std",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1348,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1257,7 +1369,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1637,6 +1749,18 @@ name = "glam"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -2567,6 +2691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2835,9 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -3554,6 +3690,7 @@ dependencies = [
  "auto-launch",
  "base64",
  "clap",
+ "dark-light",
  "dirs",
  "env_logger",
  "futures-util",
@@ -4001,12 +4138,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4016,7 +4174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -4067,8 +4234,8 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -5432,6 +5599,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5494,6 +5662,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -6182,6 +6356,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6214,6 +6397,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6260,6 +6458,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6272,6 +6476,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6281,6 +6491,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6308,6 +6524,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6317,6 +6539,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6332,6 +6560,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6341,6 +6575,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6413,6 +6653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6547,7 +6797,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-lite",
  "hex",
@@ -6775,6 +7025,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow",
  "zvariant_derive",
  "zvariant_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ keyring = { version = "3.6", features = ["apple-native", "windows-native", "sync
 jiff = "0.2.31"
 clap = { version = "4.6.1", features = ["derive"] }
 auto-launch = "0.6.0"
+dark-light = "2.0.0"
 
 [[bin]]
 name = "open-weather-wizard"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ accumulating here.
 
 **Interface**
 
+- Dark mode is now a three-way "Theme" choice in Preferences (Light / Dark / Follow System) instead of a single toggle. "Follow System" matches the OS's current light/dark preference at launch and re-checks it on the same cadence as the weather refresh. Existing `dark_mode` settings are migrated automatically to an explicit Light/Dark choice, never silently switched to "Follow System". (#47)
 - Active weather alerts (severe thunderstorm, flood, etc.) now surface as a banner above the current-conditions card when using the Google Weather provider, fetched via `publicAlerts:lookup` on the same refresh cycle as current conditions. OpenWeatherMap has no free-tier alerts equivalent, so it always shows none. (#45)
 - The auto-refresh interval is now user-configurable in Preferences (presets: 30s / 1m / 5m / 15m / 30m). To protect Google Maps Platform rate limits, a 15-minute floor is strictly enforced when using the Google Weather provider. (#44)
 - Preferences now has a "Verify API" button next to the API Token field:

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,9 @@ use std::time::{Duration, Instant};
 use iced::widget::Space;
 use iced::{Element, Size, Subscription, Task, Theme, window};
 
-use crate::config::{AppConfig, ConfigManager, LocationConfig, WeatherApiProvider};
+use crate::config::{
+    AppConfig, ConfigManager, LocationConfig, ThemePreference, WeatherApiProvider,
+};
 use crate::ui::temperature::{
     celsius_to_display, compass_direction, distance_to_display, distance_unit, format_local_time,
     pressure_to_display, pressure_unit, speed_to_display, speed_unit, unit_symbol,
@@ -115,6 +117,12 @@ pub struct AppState {
     pub weather: WeatherStatus,
     pub forecast: ForecastStatus,
     pub alerts: Vec<WeatherAlert>,
+    /// The OS's current light/dark preference, as of the last
+    /// `detect_system_theme_task` poll -- only consulted by `theme()` when
+    /// `config.theme_preference` (or the live Preferences draft) is
+    /// `ThemePreference::System`. Defaults to `Theme::Light` until the
+    /// first detection (fired at boot) resolves.
+    pub system_theme: Theme,
     /// When `weather` last transitioned to `Loaded`, for the "Updated Xs ago"
     /// label. `main_screen` re-renders often enough (via `AnimationTick`,
     /// already needed for the animated icons) that this stays fresh without
@@ -148,6 +156,10 @@ pub enum Message {
     WeatherFetched(Result<ApiResponse, String>),
     ForecastFetched(Result<ForecastResponse, String>),
     AlertsFetched(Result<Vec<WeatherAlert>, String>),
+    /// Result of `detect_system_theme_task`, fired at boot and again on
+    /// every `RefreshRequested`/`Tick` -- see that function's docs for why
+    /// this is polled rather than pushed.
+    SystemThemeDetected(Theme),
 
     OpenPreferences,
     OpenAbout,
@@ -245,6 +257,32 @@ fn fetch_alerts_task(config: &AppConfig) -> Task<Message> {
                 .map_err(|e| format!("{:?}", e))
         },
         Message::AlertsFetched,
+    )
+}
+
+/// Builds a `Task` that polls the OS's current light/dark preference off
+/// the UI thread. `dark_light::detect()` is a blocking call (on Linux, a
+/// D-Bus round trip to the XDG Desktop Portal, bounded by the crate's own
+/// 25ms timeout) -- calling it directly from `theme()` would run it
+/// synchronously every time iced redraws (including on every
+/// `AnimationTick`, ~30 times a second), freezing rendering. Instead this
+/// runs on the same cadence as the weather refresh (`RefreshRequested`/
+/// `Tick`, plus once at boot) and caches the result in
+/// `AppState::system_theme`, which `theme()` only reads. This means an OS
+/// theme change while the app is running is picked up on the next refresh
+/// tick, not instantly -- `dark-light` has no event/subscription API to
+/// react to it immediately.
+fn detect_system_theme_task() -> Task<Message> {
+    Task::perform(
+        async {
+            match dark_light::detect() {
+                Ok(dark_light::Mode::Dark) => Theme::Dark,
+                Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) | Err(_) => {
+                    Theme::Light
+                }
+            }
+        },
+        Message::SystemThemeDetected,
     )
 }
 
@@ -382,6 +420,7 @@ pub fn boot() -> (AppState, Task<Message>) {
         weather: WeatherStatus::Loading,
         forecast: ForecastStatus::Loading,
         alerts: vec![],
+        system_theme: Theme::Light,
         last_updated: None,
         value_tracker: transition::ValueTracker::default(),
         selected_forecast_day: None,
@@ -394,7 +433,14 @@ pub fn boot() -> (AppState, Task<Message>) {
         config_manager,
     };
 
-    (state, Task::batch([main_open_task.discard(), second_task]))
+    (
+        state,
+        Task::batch([
+            main_open_task.discard(),
+            second_task,
+            detect_system_theme_task(),
+        ]),
+    )
 }
 
 pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
@@ -419,7 +465,12 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                 fetch_weather_task(&state.config),
                 fetch_forecast_task(&state.config),
                 fetch_alerts_task(&state.config),
+                detect_system_theme_task(),
             ])
+        }
+        Message::SystemThemeDetected(theme) => {
+            state.system_theme = theme;
+            Task::none()
         }
         Message::WeatherFetched(Ok(response)) => {
             note_weather_transitions(
@@ -717,17 +768,23 @@ pub fn subscription(state: &AppState) -> Subscription<Message> {
 }
 
 pub fn theme(state: &AppState, _window: window::Id) -> Theme {
-    // Preview the toggle live, across every window, as soon as it's
-    // flipped in Preferences -- not just after Save. `prefs_state` is a
-    // draft; falling back to the persisted config when no Preferences
-    // window is open (or once it's closed via Cancel) means an
-    // unsaved/discarded toggle doesn't leave the theme changed behind it.
-    let dark_mode = state
+    // Preview the choice live, across every window, as soon as it's changed
+    // in Preferences -- not just after Save. `prefs_state` is a draft;
+    // falling back to the persisted config when no Preferences window is
+    // open (or once it's closed via Cancel) means an unsaved/discarded
+    // change doesn't leave the theme changed behind it.
+    let preference = state
         .prefs_state
         .as_ref()
-        .map_or(state.config.dark_mode, |prefs| prefs.dark_mode);
+        .map_or(state.config.theme_preference, |prefs| {
+            prefs.theme_preference
+        });
 
-    if dark_mode { Theme::Dark } else { Theme::Light }
+    match preference {
+        ThemePreference::Light => Theme::Light,
+        ThemePreference::Dark => Theme::Dark,
+        ThemePreference::System => state.system_theme.clone(),
+    }
 }
 
 pub fn title(state: &AppState, window_id: window::Id) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,28 @@ impl std::fmt::Display for WeatherApiProvider {
     }
 }
 
+/// The user's chosen theme: an explicit choice, or follow the OS's current
+/// light/dark preference. `app::theme()` resolves `System` using a value
+/// cached from a periodic `dark_light::detect()` poll rather than calling
+/// it directly -- see `app::detect_system_theme_task`'s docs for why.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ThemePreference {
+    Light,
+    Dark,
+    #[default]
+    System,
+}
+
+impl std::fmt::Display for ThemePreference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ThemePreference::Light => write!(f, "Light"),
+            ThemePreference::Dark => write!(f, "Dark"),
+            ThemePreference::System => write!(f, "Follow System"),
+        }
+    }
+}
+
 /// A struct representing the user's configured location.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationConfig {
@@ -73,9 +95,10 @@ pub struct AppConfig {
     pub weather_provider: WeatherApiProvider,
     pub location: LocationConfig,
     /// `#[serde(default)]` so config files saved before this field existed
-    /// still load (missing -> `false`, i.e. light mode) instead of failing.
+    /// (or predating its introduction as a `ThemePreference` -- see
+    /// `legacy_dark_mode` below) default to `ThemePreference::System`.
     #[serde(default)]
-    pub dark_mode: bool,
+    pub theme_preference: ThemePreference,
     /// `#[serde(default)]` so config files saved before this field existed
     /// still load (missing -> `false`, i.e. Celsius). Conversion happens at
     /// display time in the UI layer -- the API is always fetched in metric,
@@ -101,6 +124,16 @@ pub struct AppConfig {
     /// only through `get_api_token`/`set_api_token`.
     #[serde(rename = "api_token_encoded", default, skip_serializing)]
     legacy_api_token_encoded: Option<String>,
+    /// Present only to read config files saved by a version of this app
+    /// before `dark_mode: bool` became `theme_preference: ThemePreference`.
+    /// `#[serde(skip_serializing)]` means this is never written back out --
+    /// `ConfigManager::load_config` migrates it into an explicit
+    /// `ThemePreference::Light`/`Dark` (never `System`, since a file that
+    /// had `dark_mode` at all always reflected an explicit choice, not "no
+    /// preference") and it naturally disappears from `config.json` after
+    /// the next save.
+    #[serde(rename = "dark_mode", default, skip_serializing)]
+    legacy_dark_mode: Option<bool>,
 }
 
 impl Default for AppConfig {
@@ -108,11 +141,12 @@ impl Default for AppConfig {
         Self {
             weather_provider: WeatherApiProvider::OpenWeather,
             location: LocationConfig::default(),
-            dark_mode: false,
+            theme_preference: ThemePreference::default(),
             use_fahrenheit: false,
             launch_at_login: false,
             refresh_interval_secs: None,
             legacy_api_token_encoded: None,
+            legacy_dark_mode: None,
         }
     }
 }
@@ -280,6 +314,7 @@ impl ConfigManager {
                 Ok(mut config) => {
                     log::info!("Loaded configuration from {:?}", self.config_path);
                     self.migrate_legacy_token(&mut config);
+                    migrate_legacy_dark_mode(&mut config);
                     config
                 }
                 Err(e) => {
@@ -345,5 +380,23 @@ impl ConfigManager {
                 "Found an api_token_encoded field in config file but couldn't decode it, ignoring: {e}"
             ),
         }
+    }
+}
+
+/// One-time migration for config files saved before `dark_mode: bool`
+/// became `theme_preference: ThemePreference` -- maps the old explicit
+/// boolean onto `Light`/`Dark`. Unlike `migrate_legacy_token`, this doesn't
+/// force an immediate re-save: there's no sensitive data to scrub from
+/// disk, so the harmless `dark_mode` key just lingers in the file until the
+/// next natural Save in Preferences rewrites it with `theme_preference`
+/// instead. A no-op (one `Option` check) for every config file saved since
+/// this migration was added.
+fn migrate_legacy_dark_mode(config: &mut AppConfig) {
+    if let Some(dark_mode) = config.legacy_dark_mode.take() {
+        config.theme_preference = if dark_mode {
+            ThemePreference::Dark
+        } else {
+            ThemePreference::Light
+        };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ pub mod weather_api;
 /// Contains integration and unit tests for the library.
 #[cfg(test)]
 mod tests {
-    use crate::config::{AppConfig, ConfigManager, LocationConfig, WeatherApiProvider};
+    use crate::config::{
+        AppConfig, ConfigManager, LocationConfig, ThemePreference, WeatherApiProvider,
+    };
     use crate::weather_api::weather_provider::WeatherProviderFactory;
 
     /// The API token lives in a single OS-keyring entry shared by the whole
@@ -75,6 +77,7 @@ mod tests {
         };
         config.refresh_interval_secs = Some(900);
         config.launch_at_login = true;
+        config.theme_preference = ThemePreference::Dark;
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("GoogleWeather"));
@@ -82,19 +85,28 @@ mod tests {
         assert!(json.contains("refresh_interval_secs"));
         assert!(json.contains("900"));
         assert!(json.contains("launch_at_login"));
+        assert!(json.contains("theme_preference"));
+        assert!(!json.contains("dark_mode"));
         assert!(!json.contains("api_token"));
 
         let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.location.city, "Test City");
         assert_eq!(deserialized.refresh_interval_secs, Some(900));
         assert!(deserialized.launch_at_login);
+        assert_eq!(deserialized.theme_preference, ThemePreference::Dark);
 
         // Test migration-safe default where refresh_interval_secs and
-        // launch_at_login are missing.
-        let missing_interval_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Peoria","state":"IL","country":"US"},"dark_mode":false,"use_fahrenheit":false}"#;
+        // launch_at_login are missing, and theme_preference has never been
+        // written (no "dark_mode" key at all either) -- should default to
+        // System, not fall back to Light.
+        let missing_interval_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Peoria","state":"IL","country":"US"},"use_fahrenheit":false}"#;
         let deserialized_default: AppConfig = serde_json::from_str(missing_interval_json).unwrap();
         assert_eq!(deserialized_default.refresh_interval_secs, None);
         assert!(!deserialized_default.launch_at_login);
+        assert_eq!(
+            deserialized_default.theme_preference,
+            ThemePreference::System
+        );
     }
 
     /// Verifies that the refresh interval validation logic enforces the
@@ -175,6 +187,43 @@ mod tests {
         assert!(
             !saved.contains("api_token_encoded"),
             "migration should have rewritten the file without the legacy field"
+        );
+        // The token migration's forced re-save happens after
+        // `migrate_legacy_dark_mode` has already updated `theme_preference`
+        // in memory, so the rewritten file reflects the new field too even
+        // though dark-mode migration itself never triggers its own save.
+        assert!(saved.contains("theme_preference"));
+        assert!(!saved.contains("dark_mode"));
+
+        let _ = std::fs::remove_file(&config_path);
+    }
+
+    /// Verifies that a config file saved by a version of this app before
+    /// `dark_mode: bool` became `theme_preference: ThemePreference` has its
+    /// old explicit boolean mapped onto `Light`/`Dark` on load (never onto
+    /// `System`, since a file that had `dark_mode` at all always reflected
+    /// an explicit choice). Unlike the token migration, this one doesn't
+    /// force an immediate re-save, so the legacy `dark_mode` key is still
+    /// expected to linger in the file until the next real Save.
+    #[test]
+    fn test_legacy_dark_mode_migration() {
+        let config_path = std::env::temp_dir().join(format!(
+            "open-weather-wizard-dark-mode-migration-test-{:?}.json",
+            std::thread::current().id()
+        ));
+
+        let legacy_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Test City","state":"TS","country":"TC"},"dark_mode":true,"use_fahrenheit":false}"#;
+        std::fs::write(&config_path, legacy_json).unwrap();
+
+        let manager = ConfigManager::for_path(config_path.clone());
+        let config = manager.load_config();
+
+        assert_eq!(config.theme_preference, ThemePreference::Dark);
+
+        let untouched = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            untouched.contains("dark_mode"),
+            "dark-mode migration should not force a re-save the way token migration does"
         );
 
         let _ = std::fs::remove_file(&config_path);

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -10,7 +10,7 @@ use iced::widget::{
 };
 use iced::{Alignment, Element, Font, Length, font};
 
-use crate::config::{AppConfig, WeatherApiProvider};
+use crate::config::{AppConfig, ThemePreference, WeatherApiProvider};
 use crate::ui::style;
 
 const BOLD: Font = Font {
@@ -21,6 +21,12 @@ const BOLD: Font = Font {
 const PROVIDERS: [WeatherApiProvider; 2] = [
     WeatherApiProvider::OpenWeather,
     WeatherApiProvider::GoogleWeather,
+];
+
+const THEME_PREFERENCES: [ThemePreference; 3] = [
+    ThemePreference::Light,
+    ThemePreference::Dark,
+    ThemePreference::System,
 ];
 
 /// Presets for the auto-refresh polling interval, offered as a pick list
@@ -96,7 +102,7 @@ pub struct State {
     pub city_input: String,
     pub state_input: String,
     pub country_input: String,
-    pub dark_mode: bool,
+    pub theme_preference: ThemePreference,
     pub use_fahrenheit: bool,
     pub launch_at_login: bool,
     pub refresh_interval: RefreshIntervalPreset,
@@ -146,7 +152,7 @@ impl State {
             city_input: config.location.city.clone(),
             state_input: config.location.state.clone(),
             country_input: config.location.country.clone(),
-            dark_mode: config.dark_mode,
+            theme_preference: config.theme_preference,
             use_fahrenheit: config.use_fahrenheit,
             launch_at_login: config.launch_at_login,
             refresh_interval: config
@@ -176,7 +182,7 @@ impl State {
         config.location.city = self.city_input.clone();
         config.location.state = self.state_input.clone();
         config.location.country = self.country_input.clone();
-        config.dark_mode = self.dark_mode;
+        config.theme_preference = self.theme_preference;
         config.use_fahrenheit = self.use_fahrenheit;
         config.launch_at_login = self.launch_at_login;
         config.refresh_interval_secs = Some(self.refresh_interval.to_secs());
@@ -223,7 +229,7 @@ pub enum Message {
     CityChanged(String),
     StateChanged(String),
     CountryChanged(String),
-    DarkModeToggled(bool),
+    ThemePreferenceSelected(ThemePreference),
     UnitsToggled(bool),
     LaunchAtLoginToggled(bool),
     RefreshIntervalSelected(RefreshIntervalPreset),
@@ -260,7 +266,7 @@ pub fn update(state: &mut State, message: Message) {
         Message::CityChanged(value) => state.city_input = value,
         Message::StateChanged(value) => state.state_input = value,
         Message::CountryChanged(value) => state.country_input = value,
-        Message::DarkModeToggled(value) => state.dark_mode = value,
+        Message::ThemePreferenceSelected(value) => state.theme_preference = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
         Message::LaunchAtLoginToggled(value) => state.launch_at_login = value,
         Message::RefreshIntervalSelected(value) => state.refresh_interval = value,
@@ -370,9 +376,16 @@ pub fn view(state: &State) -> Element<'_, Message> {
     let appearance_section = section(
         "\u{263e} Appearance & Refresh",
         column![
-            toggler(state.dark_mode)
-                .label("Dark mode")
-                .on_toggle(Message::DarkModeToggled),
+            labeled_row(
+                "Theme:",
+                pick_list(
+                    &THEME_PREFERENCES[..],
+                    Some(state.theme_preference),
+                    Message::ThemePreferenceSelected
+                )
+                .style(style::pick_list)
+                .into()
+            ),
             toggler(state.use_fahrenheit)
                 .label("Use Fahrenheit (\u{b0}F)")
                 .on_toggle(Message::UnitsToggled),

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -4,7 +4,8 @@
 //! styles, used across every screen instead of one-off inline colors.
 //! Backgrounds/borders/muted text are derived from the active `Theme`'s
 //! `extended_palette()` (not hardcoded) so the same styles work correctly
-//! under both `Theme::Light` and `Theme::Dark` -- see `AppConfig::dark_mode`.
+//! under both `Theme::Light` and `Theme::Dark` -- see
+//! `AppConfig::theme_preference`.
 
 use iced::widget::{button, container, text};
 use iced::{Background, Border, Color, Shadow, Theme, Vector};


### PR DESCRIPTION
## Summary
- `AppConfig.dark_mode: bool` becomes `theme_preference: ThemePreference` (`Light` / `Dark` / `System`), migrated from old config files via a `legacy_dark_mode` shadow field (same pattern as `legacy_api_token_encoded`): an explicit `true`/`false` maps onto `Dark`/`Light`, never onto `System`, since a file that had `dark_mode` at all always reflected an explicit choice. Unlike the token migration this doesn't force an immediate re-save — no sensitive data to scrub, so the harmless legacy key just lingers until the next Preferences Save.
- `app::detect_system_theme_task` polls `dark_light::detect()` off the UI thread inside a `Task::perform`, once at boot and again on every `RefreshRequested`/`Tick`, caching the result in `AppState::system_theme`. `theme()` only reads that cache — calling `detect()` directly from `theme()` would run its blocking D-Bus/syscall call on every redraw, including the ~30/sec `AnimationTick`.
- Preferences UI: the Dark mode toggler is replaced with a `pick_list`, matching the existing `RefreshIntervalPreset` pattern.
- Tests: extended `test_config_serialization` for the new field/default, and added `test_legacy_dark_mode_migration` mirroring `test_legacy_token_migration`'s structure.

## Notes
- `dark-light` pulls in a fairly heavy transitive tree (`async-std`, `ashpd`, `windows-sys 0.48` alongside this project's existing `windows 0.62`) — worth knowing since the issue flagged dependency weight as worth double-checking. It's the standard crate for cross-platform (including Flatpak-safe Linux) theme detection with no obviously lighter alternative.
- Live OS theme changes are picked up on the next refresh tick, not instantly — `dark-light` has no event/subscription API.

Closes #47

## Test plan
- [x] `cargo build --locked`
- [x] `cargo test --locked --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manually ran the app and screenshotted Preferences: "Theme: Dark" correctly reflects the migrated config, main window renders in dark theme, no panics/errors in logs