### PR TITLE
Add a language/locale preference for weather descriptions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ accumulating here.
 
 **Interface**
 
+- Weather *descriptions* ("clear sky", "light rain", etc.) can now be requested in one of 12 languages via a new "Language" picker in Preferences, next to the Provider picker. This only affects the text the weather API returns, not the app's own UI chrome (buttons, labels, etc.), which remains English-only. Existing config files default to English, matching both providers' own API default. (#48)
 - Dark mode is now a three-way "Theme" choice in Preferences (Light / Dark / Follow System) instead of a single toggle. "Follow System" matches the OS's current light/dark preference at launch and re-checks it on the same cadence as the weather refresh. Existing `dark_mode` settings are migrated automatically to an explicit Light/Dark choice, never silently switched to "Follow System". (#47)
 - Active weather alerts (severe thunderstorm, flood, etc.) now surface as a banner above the current-conditions card when using the Google Weather provider, fetched via `publicAlerts:lookup` on the same refresh cycle as current conditions. OpenWeatherMap has no free-tier alerts equivalent, so it always shows none. (#45)
 - The auto-refresh interval is now user-configurable in Preferences (presets: 30s / 1m / 5m / 15m / 30m). To protect Google Maps Platform rate limits, a 15-minute floor is strictly enforced when using the Google Weather provider. (#44)

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -48,8 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test Google Weather (mockup)
     println!("   Testing Google Weather Provider...");
-    let provider =
-        WeatherProviderFactory::create_provider(&WeatherApiProvider::GoogleWeather, None)?;
+    let provider = WeatherProviderFactory::create_provider(
+        &WeatherApiProvider::GoogleWeather,
+        None,
+        config.language,
+    )?;
 
     let weather_result = provider.get_weather(&config.location).await;
     match weather_result {

--- a/examples/google_weather_test.rs
+++ b/examples/google_weather_test.rs
@@ -11,7 +11,7 @@
 //! ```sh
 //! GOOGLE_WEATHER_API_KEY=your-key-here cargo run --example google_weather_test
 //! ```
-use open_weather_wizard::config::{LocationConfig, WeatherApiProvider};
+use open_weather_wizard::config::{Language, LocationConfig, WeatherApiProvider};
 use open_weather_wizard::weather_api::weather_provider::WeatherProviderFactory;
 
 #[tokio::main]
@@ -42,8 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &api_key[..8.min(api_key.len())]
     );
 
-    let provider =
-        WeatherProviderFactory::create_provider(&WeatherApiProvider::GoogleWeather, Some(api_key))?;
+    let provider = WeatherProviderFactory::create_provider(
+        &WeatherApiProvider::GoogleWeather,
+        Some(api_key),
+        Language::English,
+    )?;
 
     match provider.get_weather(&location).await {
         Ok(weather_data) => {

--- a/examples/openweather_test.rs
+++ b/examples/openweather_test.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let provider = WeatherProviderFactory::create_provider(
         &WeatherApiProvider::OpenWeather,
         Some(api_key.to_string()),
+        config.language,
     )?;
 
     match provider.get_weather(&config.location).await {

--- a/src/app.rs
+++ b/src/app.rs
@@ -210,7 +210,8 @@ fn fetch_weather_task(config: &AppConfig) -> Task<Message> {
     Task::perform(
         async move {
             let token = config.get_api_token().ok();
-            let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+            let provider =
+                WeatherProviderFactory::create_provider(&provider_type, token, config.language)?;
             provider
                 .get_weather(&location)
                 .await
@@ -231,7 +232,8 @@ fn fetch_forecast_task(config: &AppConfig) -> Task<Message> {
     Task::perform(
         async move {
             let token = config.get_api_token().ok();
-            let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+            let provider =
+                WeatherProviderFactory::create_provider(&provider_type, token, config.language)?;
             provider
                 .get_forecast(&location)
                 .await
@@ -250,7 +252,8 @@ fn fetch_alerts_task(config: &AppConfig) -> Task<Message> {
     Task::perform(
         async move {
             let token = config.get_api_token().ok();
-            let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+            let provider =
+                WeatherProviderFactory::create_provider(&provider_type, token, config.language)?;
             provider
                 .get_alerts(&location)
                 .await
@@ -695,10 +698,12 @@ pub fn update(state: &mut AppState, message: Message) -> Task<Message> {
                 state: prefs_state.state_input.clone(),
                 country: prefs_state.country_input.clone(),
             };
+            let language = prefs_state.language;
 
             Task::perform(
                 async move {
-                    let provider = WeatherProviderFactory::create_provider(&provider_type, token)?;
+                    let provider =
+                        WeatherProviderFactory::create_provider(&provider_type, token, language)?;
                     provider
                         .get_weather(&location)
                         .await

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,11 +128,13 @@ fn run_inner(cli: &Cli) -> Result<(), String> {
         .filter(|t| !t.is_empty())
         .or_else(|| config.get_api_token().ok().filter(|t| !t.is_empty()));
 
-    let provider = WeatherProviderFactory::create_provider(&provider_type, token).map_err(|e| {
-        format!(
-            "{e} (set {TOKEN_ENV_VAR} or configure a token via the GUI's Preferences window first)"
-        )
-    })?;
+    let provider =
+        WeatherProviderFactory::create_provider(&provider_type, token, config.language)
+            .map_err(|e| {
+                format!(
+                    "{e} (set {TOKEN_ENV_VAR} or configure a token via the GUI's Preferences window first)"
+                )
+            })?;
 
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|e| format!("Failed to start async runtime: {e}"))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,91 @@ impl std::fmt::Display for ThemePreference {
     }
 }
 
+/// A curated set of languages weather descriptions can be requested in --
+/// intentionally a closed enum, not a free-text BCP-47 field, so a typo
+/// can't silently fall back to English with no explanation (see issue #48).
+/// Codes are provider-specific: OpenWeatherMap's `lang` parameter isn't
+/// strictly BCP-47 (notably Korean is `kr`, not ISO 639-1's `ko`), while
+/// Google Weather's `languageCode` is BCP-47 -- `openweather_code`/
+/// `google_code` return whichever code that provider actually expects.
+/// Every other language in this curated set happens to share the same
+/// two-letter code across both providers.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Language {
+    #[default]
+    English,
+    Spanish,
+    French,
+    German,
+    Italian,
+    Portuguese,
+    Russian,
+    Japanese,
+    Korean,
+    Arabic,
+    Hindi,
+    Dutch,
+}
+
+impl Language {
+    /// The code OpenWeatherMap's `lang` query parameter expects.
+    pub fn openweather_code(&self) -> &'static str {
+        match self {
+            Self::English => "en",
+            Self::Spanish => "es",
+            Self::French => "fr",
+            Self::German => "de",
+            Self::Italian => "it",
+            Self::Portuguese => "pt",
+            Self::Russian => "ru",
+            Self::Japanese => "ja",
+            Self::Korean => "kr",
+            Self::Arabic => "ar",
+            Self::Hindi => "hi",
+            Self::Dutch => "nl",
+        }
+    }
+
+    /// The BCP-47 code Google Weather's `languageCode` query parameter
+    /// expects.
+    pub fn google_code(&self) -> &'static str {
+        match self {
+            Self::English => "en",
+            Self::Spanish => "es",
+            Self::French => "fr",
+            Self::German => "de",
+            Self::Italian => "it",
+            Self::Portuguese => "pt",
+            Self::Russian => "ru",
+            Self::Japanese => "ja",
+            Self::Korean => "ko",
+            Self::Arabic => "ar",
+            Self::Hindi => "hi",
+            Self::Dutch => "nl",
+        }
+    }
+}
+
+impl std::fmt::Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::English => "English",
+            Self::Spanish => "Spanish",
+            Self::French => "French",
+            Self::German => "German",
+            Self::Italian => "Italian",
+            Self::Portuguese => "Portuguese",
+            Self::Russian => "Russian",
+            Self::Japanese => "Japanese",
+            Self::Korean => "Korean",
+            Self::Arabic => "Arabic",
+            Self::Hindi => "Hindi",
+            Self::Dutch => "Dutch",
+        };
+        write!(f, "{name}")
+    }
+}
+
 /// A struct representing the user's configured location.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationConfig {
@@ -114,6 +199,13 @@ pub struct AppConfig {
     /// default per-provider rates.
     #[serde(default)]
     pub refresh_interval_secs: Option<u64>,
+    /// The language weather *descriptions* ("clear sky", "light rain") are
+    /// requested in from whichever provider is active -- not a UI
+    /// localization setting, see `Language`'s docs. `#[serde(default)]` so
+    /// config files saved before this field existed default to
+    /// `Language::English`, matching both providers' own default.
+    #[serde(default)]
+    pub language: Language,
     /// Present only to read config files saved by older versions of this
     /// app, which stored the API token base64-"encoded" (not encrypted)
     /// directly here. `#[serde(skip_serializing)]` means this is never
@@ -145,6 +237,7 @@ impl Default for AppConfig {
             use_fahrenheit: false,
             launch_at_login: false,
             refresh_interval_secs: None,
+            language: Language::default(),
             legacy_api_token_encoded: None,
             legacy_dark_mode: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod weather_api;
 #[cfg(test)]
 mod tests {
     use crate::config::{
-        AppConfig, ConfigManager, LocationConfig, ThemePreference, WeatherApiProvider,
+        AppConfig, ConfigManager, Language, LocationConfig, ThemePreference, WeatherApiProvider,
     };
     use crate::weather_api::weather_provider::WeatherProviderFactory;
 
@@ -78,6 +78,7 @@ mod tests {
         config.refresh_interval_secs = Some(900);
         config.launch_at_login = true;
         config.theme_preference = ThemePreference::Dark;
+        config.language = Language::Spanish;
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("GoogleWeather"));
@@ -86,6 +87,7 @@ mod tests {
         assert!(json.contains("900"));
         assert!(json.contains("launch_at_login"));
         assert!(json.contains("theme_preference"));
+        assert!(json.contains("\"language\":\"Spanish\""));
         assert!(!json.contains("dark_mode"));
         assert!(!json.contains("api_token"));
 
@@ -94,11 +96,13 @@ mod tests {
         assert_eq!(deserialized.refresh_interval_secs, Some(900));
         assert!(deserialized.launch_at_login);
         assert_eq!(deserialized.theme_preference, ThemePreference::Dark);
+        assert_eq!(deserialized.language, Language::Spanish);
 
         // Test migration-safe default where refresh_interval_secs and
         // launch_at_login are missing, and theme_preference has never been
         // written (no "dark_mode" key at all either) -- should default to
-        // System, not fall back to Light.
+        // System, not fall back to Light. language should default to
+        // English, matching both providers' own API default.
         let missing_interval_json = r#"{"weather_provider":"OpenWeather","location":{"city":"Peoria","state":"IL","country":"US"},"use_fahrenheit":false}"#;
         let deserialized_default: AppConfig = serde_json::from_str(missing_interval_json).unwrap();
         assert_eq!(deserialized_default.refresh_interval_secs, None);
@@ -107,6 +111,48 @@ mod tests {
             deserialized_default.theme_preference,
             ThemePreference::System
         );
+        assert_eq!(deserialized_default.language, Language::English);
+    }
+
+    /// Verifies the one deliberate divergence between the two providers'
+    /// language codes: OpenWeatherMap's `lang` parameter uses its own `"kr"`
+    /// for Korean rather than ISO 639-1/BCP-47's `"ko"`, which Google
+    /// Weather's `languageCode` does use. Every other curated language
+    /// shares an identical code across both providers -- a regression here
+    /// (e.g. someone "simplifying" the two match arms into one) would
+    /// silently request the wrong provider's descriptions in the wrong
+    /// language for Korean users specifically, with no error to surface it.
+    #[test]
+    fn test_language_codes_diverge_only_for_korean() {
+        use crate::config::Language;
+
+        let all = [
+            Language::English,
+            Language::Spanish,
+            Language::French,
+            Language::German,
+            Language::Italian,
+            Language::Portuguese,
+            Language::Russian,
+            Language::Japanese,
+            Language::Korean,
+            Language::Arabic,
+            Language::Hindi,
+            Language::Dutch,
+        ];
+
+        for language in all {
+            if language == Language::Korean {
+                assert_eq!(language.openweather_code(), "kr");
+                assert_eq!(language.google_code(), "ko");
+            } else {
+                assert_eq!(
+                    language.openweather_code(),
+                    language.google_code(),
+                    "{language} should share the same code across both providers"
+                );
+            }
+        }
     }
 
     /// Verifies that the refresh interval validation logic enforces the
@@ -265,22 +311,30 @@ mod tests {
         let result = WeatherProviderFactory::create_provider(
             &WeatherApiProvider::OpenWeather,
             Some("test_key".to_string()),
+            Language::English,
         );
         assert!(result.is_ok());
 
         // Test missing API key for OpenWeather
-        let result =
-            WeatherProviderFactory::create_provider(&WeatherApiProvider::OpenWeather, None);
+        let result = WeatherProviderFactory::create_provider(
+            &WeatherApiProvider::OpenWeather,
+            None,
+            Language::English,
+        );
         assert!(result.is_err());
 
         // Google Weather now requires a real API token, same as OpenWeather.
-        let result =
-            WeatherProviderFactory::create_provider(&WeatherApiProvider::GoogleWeather, None);
+        let result = WeatherProviderFactory::create_provider(
+            &WeatherApiProvider::GoogleWeather,
+            None,
+            Language::English,
+        );
         assert!(result.is_err());
 
         let result = WeatherProviderFactory::create_provider(
             &WeatherApiProvider::GoogleWeather,
             Some("test_key".to_string()),
+            Language::English,
         );
         assert!(result.is_ok());
     }

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -10,7 +10,7 @@ use iced::widget::{
 };
 use iced::{Alignment, Element, Font, Length, font};
 
-use crate::config::{AppConfig, ThemePreference, WeatherApiProvider};
+use crate::config::{AppConfig, Language, ThemePreference, WeatherApiProvider};
 use crate::ui::style;
 
 const BOLD: Font = Font {
@@ -27,6 +27,21 @@ const THEME_PREFERENCES: [ThemePreference; 3] = [
     ThemePreference::Light,
     ThemePreference::Dark,
     ThemePreference::System,
+];
+
+const LANGUAGES: [Language; 12] = [
+    Language::English,
+    Language::Spanish,
+    Language::French,
+    Language::German,
+    Language::Italian,
+    Language::Portuguese,
+    Language::Russian,
+    Language::Japanese,
+    Language::Korean,
+    Language::Arabic,
+    Language::Hindi,
+    Language::Dutch,
 ];
 
 /// Presets for the auto-refresh polling interval, offered as a pick list
@@ -102,6 +117,9 @@ pub struct State {
     pub city_input: String,
     pub state_input: String,
     pub country_input: String,
+    /// The language weather descriptions are requested in -- not a UI
+    /// localization setting, see `Language`'s docs.
+    pub language: Language,
     pub theme_preference: ThemePreference,
     pub use_fahrenheit: bool,
     pub launch_at_login: bool,
@@ -152,6 +170,7 @@ impl State {
             city_input: config.location.city.clone(),
             state_input: config.location.state.clone(),
             country_input: config.location.country.clone(),
+            language: config.language,
             theme_preference: config.theme_preference,
             use_fahrenheit: config.use_fahrenheit,
             launch_at_login: config.launch_at_login,
@@ -182,6 +201,7 @@ impl State {
         config.location.city = self.city_input.clone();
         config.location.state = self.state_input.clone();
         config.location.country = self.country_input.clone();
+        config.language = self.language;
         config.theme_preference = self.theme_preference;
         config.use_fahrenheit = self.use_fahrenheit;
         config.launch_at_login = self.launch_at_login;
@@ -229,6 +249,7 @@ pub enum Message {
     CityChanged(String),
     StateChanged(String),
     CountryChanged(String),
+    LanguageSelected(Language),
     ThemePreferenceSelected(ThemePreference),
     UnitsToggled(bool),
     LaunchAtLoginToggled(bool),
@@ -266,6 +287,7 @@ pub fn update(state: &mut State, message: Message) {
         Message::CityChanged(value) => state.city_input = value,
         Message::StateChanged(value) => state.state_input = value,
         Message::CountryChanged(value) => state.country_input = value,
+        Message::LanguageSelected(value) => state.language = value,
         Message::ThemePreferenceSelected(value) => state.theme_preference = value,
         Message::UnitsToggled(value) => state.use_fahrenheit = value,
         Message::LaunchAtLoginToggled(value) => state.launch_at_login = value,
@@ -308,6 +330,16 @@ pub fn view(state: &State) -> Element<'_, Message> {
                 PROVIDERS,
                 Some(state.provider.clone()),
                 Message::ProviderSelected
+            )
+            .style(style::pick_list)
+            .into()
+        ),
+        labeled_row(
+            "Language:",
+            pick_list(
+                &LANGUAGES[..],
+                Some(state.language),
+                Message::LanguageSelected
             )
             .style(style::pick_list)
             .into()

--- a/src/weather_api/google_weather_api.rs
+++ b/src/weather_api/google_weather_api.rs
@@ -25,7 +25,7 @@
 //! timezone`). The `jiff` crate resolves the correct DST-aware offset for
 //! that zone id at that instant.
 
-use crate::config::LocationConfig;
+use crate::config::{Language, LocationConfig};
 use crate::weather_api::alerts::{AlertSeverity, WeatherAlert};
 use crate::weather_api::forecast::{ForecastDay, ForecastResponse};
 use crate::weather_api::openweather_api::{
@@ -413,20 +413,68 @@ fn resolve_epoch_and_offset(rfc3339: &str, iana_zone_id: &str) -> (i64, i64) {
     (epoch, offset)
 }
 
+/// Builds the `currentConditions:lookup` query params -- a pure function so
+/// `languageCode` can be unit-tested without a live network call.
+fn current_conditions_query(
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+    language_code: &str,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("key", api_key.to_string()),
+        ("location.latitude", lat.to_string()),
+        ("location.longitude", lon.to_string()),
+        ("unitsSystem", "METRIC".to_string()),
+        ("languageCode", language_code.to_string()),
+    ]
+}
+
+/// Builds the `forecast/days:lookup` query params. See
+/// `current_conditions_query`'s docs.
+fn forecast_days_query(
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+    days: u8,
+    language_code: &str,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("key", api_key.to_string()),
+        ("location.latitude", lat.to_string()),
+        ("location.longitude", lon.to_string()),
+        ("unitsSystem", "METRIC".to_string()),
+        ("days", days.to_string()),
+        ("languageCode", language_code.to_string()),
+    ]
+}
+
+/// Builds the `publicAlerts:lookup` query params. See
+/// `current_conditions_query`'s docs.
+fn public_alerts_query(
+    api_key: &str,
+    lat: f64,
+    lon: f64,
+    language_code: &str,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("key", api_key.to_string()),
+        ("location.latitude", lat.to_string()),
+        ("location.longitude", lon.to_string()),
+        ("languageCode", language_code.to_string()),
+    ]
+}
+
 async fn fetch_current_conditions(
     client: &reqwest::Client,
     api_key: &str,
     lat: f64,
     lon: f64,
+    language_code: &str,
 ) -> Result<CurrentConditionsResponse, ApiError> {
     let response = client
         .get(format!("{WEATHER_API_BASE}/currentConditions:lookup"))
-        .query(&[
-            ("key", api_key.to_string()),
-            ("location.latitude", lat.to_string()),
-            ("location.longitude", lon.to_string()),
-            ("unitsSystem", "METRIC".to_string()),
-        ])
+        .query(&current_conditions_query(api_key, lat, lon, language_code))
         .send()
         .await
         .map_err(ApiError::RequestFailed)?;
@@ -454,16 +502,11 @@ async fn fetch_forecast_days(
     lat: f64,
     lon: f64,
     days: u8,
+    language_code: &str,
 ) -> Result<ForecastDaysResponse, ApiError> {
     let response = client
         .get(format!("{WEATHER_API_BASE}/forecast/days:lookup"))
-        .query(&[
-            ("key", api_key.to_string()),
-            ("location.latitude", lat.to_string()),
-            ("location.longitude", lon.to_string()),
-            ("unitsSystem", "METRIC".to_string()),
-            ("days", days.to_string()),
-        ])
+        .query(&forecast_days_query(api_key, lat, lon, days, language_code))
         .send()
         .await
         .map_err(ApiError::RequestFailed)?;
@@ -484,14 +527,11 @@ async fn fetch_public_alerts(
     api_key: &str,
     lat: f64,
     lon: f64,
+    language_code: &str,
 ) -> Result<PublicAlertsResponse, ApiError> {
     let response = client
         .get(format!("{WEATHER_API_BASE}/publicAlerts:lookup"))
-        .query(&[
-            ("key", api_key.to_string()),
-            ("location.latitude", lat.to_string()),
-            ("location.longitude", lon.to_string()),
-        ])
+        .query(&public_alerts_query(api_key, lat, lon, language_code))
         .send()
         .await
         .map_err(ApiError::RequestFailed)?;
@@ -538,6 +578,7 @@ fn map_forecast_day(item: &ForecastDayItem) -> ForecastDay {
 /// Platform's Weather API.
 pub struct GoogleWeatherProvider {
     api_key: String,
+    language: Language,
     /// Reused across every request this provider makes (geocoding, current
     /// conditions, forecast) rather than building a fresh `reqwest::Client`
     /// per call -- a `Client` holds a connection pool internally, so
@@ -548,10 +589,12 @@ pub struct GoogleWeatherProvider {
 
 impl GoogleWeatherProvider {
     /// Creates a new `GoogleWeatherProvider` with the given Google Cloud API
-    /// key (must have the Weather API enabled on its project).
-    pub fn new(api_key: String) -> Self {
+    /// key (must have the Weather API enabled on its project) and the
+    /// language to request weather descriptions in.
+    pub fn new(api_key: String, language: Language) -> Self {
         Self {
             api_key,
+            language,
             client: reqwest::Client::new(),
         }
     }
@@ -561,11 +604,14 @@ impl GoogleWeatherProvider {
 impl WeatherProvider for GoogleWeatherProvider {
     async fn get_weather(&self, location: &LocationConfig) -> Result<ApiResponse, ApiError> {
         let (lat, lon) = geocode(&self.client, location).await?;
+        let language_code = self.language.google_code();
 
-        let current = fetch_current_conditions(&self.client, &self.api_key, lat, lon).await?;
+        let current =
+            fetch_current_conditions(&self.client, &self.api_key, lat, lon, language_code).await?;
         // Sunrise/sunset and today's min/max only come from the daily
         // forecast, not currentConditions -- see the module doc.
-        let forecast = fetch_forecast_days(&self.client, &self.api_key, lat, lon, 1).await?;
+        let forecast =
+            fetch_forecast_days(&self.client, &self.api_key, lat, lon, 1, language_code).await?;
         let today = forecast
             .forecast_days
             .first()
@@ -603,8 +649,15 @@ impl WeatherProvider for GoogleWeatherProvider {
 
     async fn get_forecast(&self, location: &LocationConfig) -> Result<ForecastResponse, ApiError> {
         let (lat, lon) = geocode(&self.client, location).await?;
-        let forecast =
-            fetch_forecast_days(&self.client, &self.api_key, lat, lon, FORECAST_DAYS).await?;
+        let forecast = fetch_forecast_days(
+            &self.client,
+            &self.api_key,
+            lat,
+            lon,
+            FORECAST_DAYS,
+            self.language.google_code(),
+        )
+        .await?;
 
         Ok(ForecastResponse {
             location_name: location.city.clone(),
@@ -618,7 +671,14 @@ impl WeatherProvider for GoogleWeatherProvider {
 
     async fn get_alerts(&self, location: &LocationConfig) -> Result<Vec<WeatherAlert>, ApiError> {
         let (lat, lon) = geocode(&self.client, location).await?;
-        let alerts_response = fetch_public_alerts(&self.client, &self.api_key, lat, lon).await?;
+        let alerts_response = fetch_public_alerts(
+            &self.client,
+            &self.api_key,
+            lat,
+            lon,
+            self.language.google_code(),
+        )
+        .await?;
 
         let alerts = alerts_response
             .public_alerts
@@ -678,6 +738,25 @@ mod tests {
     fn test_unit_conversions() {
         assert!((kmh_to_mps(3.6) - 1.0).abs() < 1e-9);
         assert!((km_to_meters(10.0) - 10_000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_current_conditions_query_includes_language_code() {
+        let query = current_conditions_query("test-key", 1.0, 2.0, "fr");
+        assert!(query.contains(&("languageCode", "fr".to_string())));
+    }
+
+    #[test]
+    fn test_forecast_days_query_includes_language_code() {
+        let query = forecast_days_query("test-key", 1.0, 2.0, 5, "ko");
+        assert!(query.contains(&("languageCode", "ko".to_string())));
+        assert!(query.contains(&("days", "5".to_string())));
+    }
+
+    #[test]
+    fn test_public_alerts_query_includes_language_code() {
+        let query = public_alerts_query("test-key", 1.0, 2.0, "hi");
+        assert!(query.contains(&("languageCode", "hi".to_string())));
     }
 
     #[test]

--- a/src/weather_api/openweather_api.rs
+++ b/src/weather_api/openweather_api.rs
@@ -16,7 +16,7 @@
 //! - **Provider Implementation**: Implements the `WeatherProvider` trait for seamless
 //!   integration into the application's provider factory.
 //!
-use crate::config::LocationConfig;
+use crate::config::{Language, LocationConfig};
 use crate::weather_api::weather_provider::{WeatherProvider, location_config_to_location};
 use async_trait::async_trait;
 use reqwest;
@@ -213,6 +213,21 @@ async fn resolve_location(location: &Location, api_key: &str) -> Result<Location
     })
 }
 
+/// Builds the `data/2.5/weather` request URL -- a pure function so the
+/// `lang` query param can be unit-tested without a live network call.
+fn weather_url(lat: f64, lon: f64, api_key: &str, lang: &str) -> String {
+    format!(
+        "https://api.openweathermap.org/data/2.5/weather?lat={lat}&lon={lon}&appid={api_key}&units=metric&lang={lang}"
+    )
+}
+
+/// Builds the `data/2.5/forecast` request URL. See `weather_url`'s docs.
+fn forecast_url(lat: f64, lon: f64, api_key: &str, lang: &str) -> String {
+    format!(
+        "https://api.openweathermap.org/data/2.5/forecast?lat={lat}&lon={lon}&appid={api_key}&units=metric&lang={lang}"
+    )
+}
+
 /// Fetches weather data for a given location using the OpenWeatherMap API.
 ///
 /// This is a two-step process:
@@ -222,15 +237,18 @@ async fn resolve_location(location: &Location, api_key: &str) -> Result<Location
 /// # Arguments
 /// * `location` - The location to fetch weather for.
 /// * `api_key` - Your personal OpenWeatherMap API key.
-pub async fn get_weather(location: &Location, api_key: &str) -> Result<ApiResponse, ApiError> {
+/// * `lang` - The OpenWeatherMap `lang` code (see `Language::openweather_code`)
+///   to request the `description` field in. Only that field is translated;
+///   numeric fields are unaffected.
+pub async fn get_weather(
+    location: &Location,
+    api_key: &str,
+    lang: &str,
+) -> Result<ApiResponse, ApiError> {
     // Get coordinates for the location
     let weather_location = resolve_location(location, api_key).await?;
 
-    // Construct the API URL. We use metric units for Celsius.
-    let url = format!(
-        "https://api.openweathermap.org/data/2.5/weather?lat={}&lon={}&appid={}&units=metric",
-        weather_location.lat, weather_location.lon, api_key
-    );
+    let url = weather_url(weather_location.lat, weather_location.lon, api_key, lang);
 
     // Make the asynchronous GET request
     let response = reqwest::get(&url).await.map_err(ApiError::RequestFailed)?;
@@ -255,16 +273,15 @@ pub async fn get_weather(location: &Location, api_key: &str) -> Result<ApiRespon
 /// # Arguments
 /// * `location` - The location to fetch a forecast for.
 /// * `api_key` - Your personal OpenWeatherMap API key.
+/// * `lang` - See `get_weather`'s docs.
 pub async fn get_forecast(
     location: &Location,
     api_key: &str,
+    lang: &str,
 ) -> Result<crate::weather_api::forecast::ForecastResponse, ApiError> {
     let weather_location = resolve_location(location, api_key).await?;
 
-    let url = format!(
-        "https://api.openweathermap.org/data/2.5/forecast?lat={}&lon={}&appid={}&units=metric",
-        weather_location.lat, weather_location.lon, api_key
-    );
+    let url = forecast_url(weather_location.lat, weather_location.lon, api_key, lang);
 
     let response = reqwest::get(&url).await.map_err(ApiError::RequestFailed)?;
     log::debug!("Forecast API response: {}", response.status());
@@ -314,6 +331,7 @@ pub fn get_weather_symbol(weather_condition: &str) -> WeatherSymbol {
 /// An implementation of the `WeatherProvider` trait for the OpenWeatherMap service.
 pub struct OpenWeatherProvider {
     api_key: String,
+    language: Language,
 }
 
 impl OpenWeatherProvider {
@@ -321,8 +339,9 @@ impl OpenWeatherProvider {
     ///
     /// # Arguments
     /// * `api_key` - The API key for the OpenWeatherMap service.
-    pub fn new(api_key: String) -> Self {
-        Self { api_key }
+    /// * `language` - The language to request weather descriptions in.
+    pub fn new(api_key: String, language: Language) -> Self {
+        Self { api_key, language }
     }
 }
 
@@ -334,7 +353,12 @@ impl WeatherProvider for OpenWeatherProvider {
     /// struct suitable for the API and then calls the internal `get_weather` function.
     async fn get_weather(&self, location: &LocationConfig) -> Result<ApiResponse, ApiError> {
         let api_location = location_config_to_location(location);
-        get_weather(&api_location, &self.api_key).await
+        get_weather(
+            &api_location,
+            &self.api_key,
+            self.language.openweather_code(),
+        )
+        .await
     }
 
     /// Fetches a forecast by implementing the `WeatherProvider` trait.
@@ -343,13 +367,33 @@ impl WeatherProvider for OpenWeatherProvider {
         location: &LocationConfig,
     ) -> Result<crate::weather_api::forecast::ForecastResponse, ApiError> {
         let api_location = location_config_to_location(location);
-        get_forecast(&api_location, &self.api_key).await
+        get_forecast(
+            &api_location,
+            &self.api_key,
+            self.language.openweather_code(),
+        )
+        .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_weather_url_includes_language_code() {
+        let url = weather_url(1.0, 2.0, "test-key", "es");
+        assert!(url.contains("lang=es"));
+        assert!(url.contains("units=metric"));
+    }
+
+    #[test]
+    fn test_forecast_url_includes_language_code() {
+        // Korean uses OpenWeatherMap's own "kr" code, not ISO 639-1's "ko" --
+        // see `Language::openweather_code`'s docs.
+        let url = forecast_url(1.0, 2.0, "test-key", "kr");
+        assert!(url.contains("lang=kr"));
+    }
 
     #[test]
     fn test_get_weather_symbol_known_conditions() {

--- a/src/weather_api/weather_provider.rs
+++ b/src/weather_api/weather_provider.rs
@@ -13,7 +13,7 @@
 //!   instances of `WeatherProvider` (e.g., `OpenWeatherProvider`, `GoogleWeatherProvider`)
 //!   based on the application's configuration.
 
-use crate::config::{LocationConfig, WeatherApiProvider};
+use crate::config::{Language, LocationConfig, WeatherApiProvider};
 use crate::weather_api::alerts::WeatherAlert;
 use crate::weather_api::forecast::ForecastResponse;
 use crate::weather_api::openweather_api::{ApiError, ApiResponse, Location};
@@ -63,24 +63,27 @@ impl WeatherProviderFactory {
     ///
     /// * `provider_type` - The type of weather provider to create.
     /// * `api_token` - An `Option` containing the API token, if required by the provider.
+    /// * `language` - The language to request weather *descriptions* in --
+    ///   see `Language`'s docs.
     ///
     /// # Errors
     /// Returns an error `String` if a required API token is missing for the selected provider.
     pub fn create_provider(
         provider_type: &WeatherApiProvider,
         api_token: Option<String>,
+        language: Language,
     ) -> Result<Box<dyn WeatherProvider + Send + Sync>, String> {
         match provider_type {
             WeatherApiProvider::OpenWeather => {
                 let token = api_token.ok_or("OpenWeather API requires an API token")?;
                 Ok(Box::new(super::openweather_api::OpenWeatherProvider::new(
-                    token,
+                    token, language,
                 )))
             }
             WeatherApiProvider::GoogleWeather => {
                 let token = api_token.ok_or("Google Weather API requires an API token")?;
                 Ok(Box::new(
-                    super::google_weather_api::GoogleWeatherProvider::new(token),
+                    super::google_weather_api::GoogleWeatherProvider::new(token, language),
                 ))
             }
         }


### PR DESCRIPTION
## Summary
- `config::Language`: a closed 12-language enum (not free-text BCP-47) so a typo can't silently fall back to English. Exposes `openweather_code()`/`google_code()` separately since the two providers' schemes mostly overlap but diverge for Korean (OpenWeatherMap's own `"kr"` vs. ISO 639-1/BCP-47's `"ko"`) — a regression here would silently request the wrong language with no error, so it's covered by a dedicated `test_language_codes_diverge_only_for_korean` test.
- `AppConfig.language`, `#[serde(default)]` to `Language::English`, matching both providers' own API default — no migration needed, this is a brand-new field.
- `WeatherProviderFactory::create_provider` now takes a `Language`; both providers store it and thread it into every request (OpenWeatherMap's `&lang=`, Google's `languageCode=`, including `publicAlerts:lookup` for consistency with #45). The Preferences "Verify API" connection test uses the live draft's language, not the saved config, matching how it already treats provider/token/location.
- Preferences UI: a "Language" `pick_list` next to the Provider picker.
- URL/query-string construction pulled into small pure functions (`weather_url`/`forecast_url`, `current_conditions_query`/`forecast_days_query`/`public_alerts_query`) so the query params are unit-testable without a live network call, per the issue's scope item.
- Updated the 3 example binaries that construct providers directly.

## Out of scope (per the issue)
Translating the app's own UI chrome — this is about the weather *data* language only.

Closes #48

## Test plan
- [x] `cargo build --locked` (including `--examples`)
- [x] `cargo test --locked --all` (61 tests, including 6 new ones covering the URL/query builders and the Korean code divergence)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manually ran the app against the real OpenWeatherMap API and confirmed translated descriptions came back correctly (Hindi text) after switching languages